### PR TITLE
Fix bug where we try to sort a generator

### DIFF
--- a/ykman/cli/oath.py
+++ b/ykman/cli/oath.py
@@ -304,7 +304,7 @@ Touch and HOTP credentials require a single match to be triggered.
     ensure_validated(ctx)
 
     controller = ctx.obj['controller']
-    creds = controller.calculate_all()
+    creds = [c for c in controller.calculate_all()]
 
     # Remove hidden creds
     if not show_hidden:


### PR DESCRIPTION
## To reproduce:

    > ykman oath code -H
    File "/Users/dchang/Build/yubikey-manager/ykman/cli/oath.py", line 327, in code
        creds.sort()
    AttributeError: 'generator' object has no attribute 'sort'


## Issue:
We try to run `creds.sort()` - however, if the `show hidden -h` flag is on,
then we never change the generator into a list, causing an error.

## Solution:
Change `creds` into a list immediately.

## Why not other solutions?

I would have preferred `creds = list(controller.calculate_all())`.
However, using list comprehension rather than the list constructor is
used when we list all credentials, hence matching the style of other
code.

(It's worth noting that because we called a function `list` and thus
overrode the list constructor, running `list()` on any generator was
going to fail.)

We could have also used `sorted()` instead of `creds.sort()`. However,
the code for finding the longest name assumes that it's a list not a
generator as otherwise, it will exhaust the generator and leave nothing
to output.