### PR TITLE
Strip out spaces from OATH base32 code entry

### DIFF
--- a/test/test_cli_commands_on_yubikey.py
+++ b/test/test_cli_commands_on_yubikey.py
@@ -177,6 +177,11 @@ class TestOATH(unittest.TestCase):
         creds = ykman_cli('oath', 'list')
         self.assertIn('test-name', creds)
 
+    def test_oath_add_credential_with_space(self):
+        ykman_cli('oath', 'add', 'test-name-space', 'ab ba')
+        creds = ykman_cli('oath', 'list')
+        self.assertIn('test-name-space', creds)
+
     def test_oath_hidden_cred(self):
         ykman_cli('oath', 'add', '_hidden:name', 'abba')
         creds = ykman_cli('oath', 'code')

--- a/ykman/cli/util.py
+++ b/ykman/cli/util.py
@@ -82,7 +82,7 @@ def parse_key(val):
 
 
 def parse_b32_key(key):
-    key = key.upper()
+    key = key.upper().replace(' ', '')
     key += '=' * (-len(key) % 8)  # Support unpadded
     return b32decode(key)
 


### PR DESCRIPTION
Some services (e.g. Dropbox, Google) will have spaces in the base32
code. They do it because base32 does not contain spaces and it makes it
easier for a human to read and type.

In the case of ykman, it's likely that folks copy and paste the code and
thus will also copy over the spaces. As it is safe to ignore the spaces,
we should.