### PR TITLE
add repl support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ from ykman.yubicommon.setup import setup
 
 
 install_requires = [
-    'six', 'pyscard', 'pyusb', 'click', 'cryptography', 'pyopenssl']
+    'six', 'pyscard', 'pyusb', 'click', 'cryptography', 'pyopenssl', 'click-repl']
 if sys.version_info < (3, 4):
     install_requires.append('enum34')
 if sys.platform == 'win32':

--- a/ykman/cli/__main__.py
+++ b/ykman/cli/__main__.py
@@ -42,6 +42,7 @@ from .oath import oath
 from .piv import piv
 import usb.core
 import click
+import click_repl
 import sys
 
 
@@ -80,8 +81,11 @@ def cli(ctx):
     """
     Configure your YubiKey via the command line.
     """
-    subcmd = next(c for c in COMMANDS if c.name == ctx.invoked_subcommand)
-    transports = getattr(subcmd, 'transports', TRANSPORT.usb_transports())
+    if ctx.invoked_subcommand == 'repl':
+        transports = TRANSPORT.usb_transports()
+    else:
+        subcmd = next(c for c in COMMANDS if c.name == ctx.invoked_subcommand)
+        transports = getattr(subcmd, 'transports', TRANSPORT.usb_transports())
     if transports:
         try:
             descriptors = list(get_descriptors())
@@ -111,6 +115,7 @@ def cli(ctx):
 for cmd in COMMANDS:
     cli.add_command(cmd)
 
+click_repl.register_repl(cli)
 
 def main():
     try:


### PR DESCRIPTION
This fixes #21 . It does expect a yubikey that has all modes enabled, since it can't do cuteness in the transport checks given it doesn't know what commands the user will run, but I'm not sure how to set up that kind of check w/o more smarts