### PR TITLE
Updated macOS Install instructions

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -37,6 +37,8 @@ Commands:
 
 ==== macOS
 
+    $ brew install ykman
+
 Or from source:
 
     $ brew install swig ykpers libu2f-host libusb

--- a/README.adoc
+++ b/README.adoc
@@ -37,8 +37,10 @@ Commands:
 
 ==== macOS
 
-    $ brew install python3 swig ykpers libu2f-host libusb
-    $ pip3 install yubikey-manager
+Or from source:
+
+    $ brew install swig ykpers libu2f-host libusb
+    $ pip install --user yubikey-manager
 
 ==== Pip
 


### PR DESCRIPTION
Added ` brew install ykman` as the main installation method.

Also changed to use _Python 2_  as the default instructions for installing from source since that is (still) the default on macOS.