### PR TITLE
OpenPGP: print remaining PIN retries in info cmd

### DIFF
--- a/ykman/cli/opgp.py
+++ b/ykman/cli/opgp.py
@@ -98,9 +98,9 @@ def info(ctx):
     controller = ctx.obj['controller']
     click.echo('OpenPGP version: %d.%d.%d' % controller.version)
     retries = controller.get_remaining_pin_tries()
-    click.echo('PIN tries remaining: {}'.format(retries['pin']))
-    click.echo('Reset code tries remaining: {}'.format(retries['reset']))
-    click.echo('Admin PIN tries remaining: {}'.format(retries['admin']))
+    click.echo('PIN tries remaining: {}'.format(retries.pin))
+    click.echo('Reset code tries remaining: {}'.format(retries.reset))
+    click.echo('Admin PIN tries remaining: {}'.format(retries.admin))
 
 
 @openpgp.command()

--- a/ykman/cli/opgp.py
+++ b/ykman/cli/opgp.py
@@ -98,9 +98,9 @@ def info(ctx):
     controller = ctx.obj['controller']
     click.echo('OpenPGP version: %d.%d.%d' % controller.version)
     retries = controller.get_remaining_pin_tries()
-    click.echo('PIN tries remaining: {}'.format(retries[0]))
-    click.echo('Reset code tries remaining: {}'.format(retries[1]))
-    click.echo('Admin PIN tries remaining: {}'.format(retries[2]))
+    click.echo('PIN tries remaining: {}'.format(retries['pin']))
+    click.echo('Reset code tries remaining: {}'.format(retries['reset']))
+    click.echo('Admin PIN tries remaining: {}'.format(retries['admin']))
 
 
 @openpgp.command()

--- a/ykman/cli/opgp.py
+++ b/ykman/cli/opgp.py
@@ -97,6 +97,10 @@ def info(ctx):
     """
     controller = ctx.obj['controller']
     click.echo('OpenPGP version: %d.%d.%d' % controller.version)
+    retries = controller.get_remaining_pin_tries()
+    click.echo('PIN tries remaining: {}'.format(retries[0]))
+    click.echo('Reset code tries remaining: {}'.format(retries[1]))
+    click.echo('Admin PIN tries remaining: {}'.format(retries[2]))
 
 
 @openpgp.command()

--- a/ykman/opgp.py
+++ b/ykman/opgp.py
@@ -91,12 +91,12 @@ class OpgpController(object):
         bcd_hex = b2a_hex(self.send_apdu(0, INS.GET_VERSION, 0, 0))
         return tuple(int(bcd_hex[i:i+2]) for i in range(0, 6, 2))
 
-    def _get_pin_tries(self):
+    def get_remaining_pin_tries(self):
         data = self.send_apdu(0, INS.GET_DATA, 0, 0xc4)
         return tuple(six.iterbytes(data[4:7]))
 
     def _block_pins(self):
-        pw1_tries, _, pw3_tries = self._get_pin_tries()
+        pw1_tries, _, pw3_tries = self.get_remaining_pin_tries()
 
         for _ in range(pw1_tries):
             self.send_apdu(0, INS.VERIFY, 0, PW1, INVALID_PIN, check=None)
@@ -115,7 +115,7 @@ class OpgpController(object):
         try:
             self.send_apdu(0, INS.VERIFY, 0, pw, pin)
         except APDUError:
-            pw_remaining = self._get_pin_tries()[pw-PW1]
+            pw_remaining = self.get_remaining_pin_tries()[pw-PW1]
             raise ValueError('Invalid PIN, {} tries remaining.'.format(
                 pw_remaining))
 

--- a/ykman/opgp.py
+++ b/ykman/opgp.py
@@ -95,12 +95,9 @@ class OpgpController(object):
         bcd_hex = b2a_hex(self.send_apdu(0, INS.GET_VERSION, 0, 0))
         return tuple(int(bcd_hex[i:i+2]) for i in range(0, 6, 2))
 
-    def _get_remaining_pin_tries(self):
-        data = self.send_apdu(0, INS.GET_DATA, 0, 0xc4)
-        return tuple(six.iterbytes(data[4:7]))
-
     def get_remaining_pin_tries(self):
-        return PinRetries(*self._get_remaining_pin_tries())
+        data = self.send_apdu(0, INS.GET_DATA, 0, 0xc4)
+        return PinRetries(*six.iterbytes(data[4:7]))
 
     def _block_pins(self):
         retries = self.get_remaining_pin_tries()
@@ -122,7 +119,7 @@ class OpgpController(object):
         try:
             self.send_apdu(0, INS.VERIFY, 0, pw, pin)
         except APDUError:
-            pw_remaining = self._get_remaining_pin_tries()[pw-PW1]
+            pw_remaining = self.get_remaining_pin_tries()[pw-PW1]
             raise ValueError('Invalid PIN, {} tries remaining.'.format(
                 pw_remaining))
 


### PR DESCRIPTION
CLI: Print remaining PIN retries in `$ ykman openpgp info` command
API: make `get_remaining_pin_tries()` a public method.
 