### PR TITLE
Log lightly handled errors

### DIFF
--- a/ykman/cli/__main__.py
+++ b/ykman/cli/__main__.py
@@ -44,7 +44,11 @@ from .piv import piv
 import ykman.cli.logging_setup
 import usb.core
 import click
+import logging
 import sys
+
+
+logger = logging.getLogger(__name__)
 
 
 CLICK_CONTEXT_SETTINGS = dict(
@@ -187,10 +191,12 @@ def main():
     try:
         cli(obj={})
     except ValueError as e:
+        logger.error('Error', exc_info=e)
         print('Error:', e)
         return 1
 
     except Cve201715361VulnerableError as err:
+        logger.error('Error', exc_info=err)
         print('Error:', err)
         return 2
 

--- a/ykman/cli/mode.py
+++ b/ykman/cli/mode.py
@@ -30,8 +30,12 @@ from __future__ import absolute_import
 from .util import click_force_option
 from ..util import Mode, TRANSPORT
 from ..driver import ModeSwitchError
+import logging
 import re
 import click
+
+
+logger = logging.getLogger(__name__)
 
 
 def _parse_transport_string(transport):
@@ -123,7 +127,8 @@ def mode(ctx, mode, touch_eject, autoeject_timeout, chalresp_timeout, force):
             dev.set_mode(mode, chalresp_timeout, autoeject)
             click.echo('Mode set! You must remove and re-insert your YubiKey '
                        'for this change to take effect.')
-        except ModeSwitchError:
+        except ModeSwitchError as e:
+            logger.debug('Failed to switch mode', exc_info=e)
             click.echo('Failed to switch mode on the YubiKey. Make sure your '
                        'YubiKey does not have an access code set.')
 

--- a/ykman/cli/oath.py
+++ b/ykman/cli/oath.py
@@ -27,6 +27,7 @@
 
 from __future__ import absolute_import
 import click
+import logging
 from threading import Timer
 from binascii import b2a_hex, a2b_hex
 from .util import (
@@ -37,6 +38,9 @@ from ..driver_ccid import APDUError,  SW_APPLICATION_NOT_FOUND
 from ..util import TRANSPORT, parse_b32_key
 from ..oath import OathController, SW, CredentialData, OATH_TYPE, ALGO
 from ..settings import Settings
+
+
+logger = logging.getLogger(__name__)
 
 click_touch_option = click.option(
     '-t', '--touch', is_flag=True,
@@ -474,7 +478,8 @@ def ensure_validated(ctx, prompt='Enter your password', remember=False):
             try:
                 controller.validate(a2b_hex(keys[controller.id]))
                 return
-            except Exception:
+            except Exception as e:
+                logger.debug('Error', exc_info=e)
                 del keys[controller.id]
 
         # Prompt for password

--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -451,7 +451,7 @@ def set_pin_retries(ctx, management_key, pin, pin_retries, puk_retries, force):
         click.echo('PIN:    123456')
         click.echo('PUK:    12345678')
     except Exception as e:
-        logger.error('Failed to set PIN retries', e)
+        logger.error('Failed to set PIN retries', exc_info=e)
         ctx.fail('Setting pin retries failed.')
 
 

--- a/ykman/cli/slot.py
+++ b/ykman/cli/slot.py
@@ -59,7 +59,7 @@ click_slot_argument = click.argument('slot', type=click.Choice(['1', '2']),
 
 
 def _failed_to_write_msg(ctx, exc_info):
-    logger.error('Failed to write message to driver', exc_info=exc_info)
+    logger.error('Failed to write to device', exc_info=exc_info)
     ctx.fail('Failed to write to the YubiKey. Make sure the device does not '
              'have restricted access.')
 

--- a/ykman/descriptor.py
+++ b/ykman/descriptor.py
@@ -114,8 +114,8 @@ def _gen_descriptors():
             if addr not in found:
                 found.append(addr)
                 yield Descriptor.from_usb(dev)
-        except ValueError:
-            pass  # Invalid PID.
+        except ValueError as e:
+            logger.debug('Invalid PID', exc_info=e)
 
 
 def get_descriptors():

--- a/ykman/driver_ccid.py
+++ b/ykman/driver_ccid.py
@@ -101,14 +101,19 @@ class CCIDDriver(AbstractDriver):
         self._conn = connection
         self._pid = _pid_from_name(name)
         try:
+            self._read_version()
+        except APDUError as e:
+            logger.error('Failed to read firmware version', exc_info=e)
+        try:
             self._read_serial()
         except APDUError as e:
-            # Can't read serial or version
             logger.error('Failed to read serial number', exc_info=e)
 
-    def _read_serial(self):
+    def _read_version(self):
         s = self.send_apdu(0, INS_SELECT, 4, 0, AID.OTP)
         self._version = tuple(c for c in six.iterbytes(s[:3]))
+
+    def _read_serial(self):
         serial = self.send_apdu(0, INS_YK2_REQ, SLOT_DEVICE_SERIAL, 0)
         if len(serial) == 4:
             self._serial = struct.unpack('>I', serial)[0]

--- a/ykman/driver_otp.py
+++ b/ykman/driver_otp.py
@@ -59,7 +59,8 @@ try:
         raise Exception('yk_init failed.')
     libversion = tuple(int(x) for x in ykpers.ykpers_check_version(None)
                        .decode('ascii').split('.'))
-except Exception:
+except Exception as e:
+    logger.error('libykpers not found', exc_info=e)
     ykpers = MissingLibrary(
         'libykpers not found, slot functionality not available!')
     libversion = None

--- a/ykman/driver_u2f.py
+++ b/ykman/driver_u2f.py
@@ -32,10 +32,13 @@ from .driver import AbstractDriver, ModeSwitchError
 from .util import TRANSPORT, YUBIKEY, PID, MissingLibrary, parse_tlvs
 from ctypes import POINTER, byref, c_uint, c_size_t, create_string_buffer
 from binascii import b2a_hex
+import logging
 import weakref
 import struct
 import six
 
+
+logger = logging.getLogger(__name__)
 
 INS_SELECT = 0xa4
 INS_YK4_CAPABILITIES = 0x1d
@@ -55,7 +58,8 @@ try:
         raise Exception('u2fh_global_init failed!')
     libversion = tuple(int(x) for x in u2fh.u2fh_check_version(None)
                        .decode('ascii').split('.'))
-except Exception:
+except Exception as e:
+    logger.error('libu2f-host not found', exc_info=e)
     u2fh = MissingLibrary(
         'libu2f-host not found, U2F connectability not available!')
     libversion = None

--- a/ykman/piv.py
+++ b/ykman/piv.py
@@ -43,9 +43,13 @@ from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.backends import default_backend
 from collections import OrderedDict
 from threading import Timer
+import logging
 import struct
 import six
 import os
+
+
+logger = logging.getLogger(__name__)
 
 
 @unique
@@ -588,9 +592,8 @@ class PivController(object):
                 self.put_data(
                     OBJ.PIVMAN_PROTECTED_DATA,
                     self._pivman_protected_data.get_bytes())
-            except APDUError:
-                # No pin provided, can't clear key..
-                pass
+            except APDUError as e:
+                logger.debug("No pin provided, can't clear key..", exc_info=e)
 
     def get_pin_tries(self):
         """
@@ -730,7 +733,7 @@ class PivController(object):
         for slot in set(SLOT) - {SLOT.CARD_MANAGEMENT, SLOT.ATTESTATION}:
             try:
                 certs[slot] = self.read_certificate(slot)
-            except APDUError:
+            except APDUError as e:
                 pass
         return certs
 

--- a/ykman/piv.py
+++ b/ykman/piv.py
@@ -733,7 +733,7 @@ class PivController(object):
         for slot in set(SLOT) - {SLOT.CARD_MANAGEMENT, SLOT.ATTESTATION}:
             try:
                 certs[slot] = self.read_certificate(slot)
-            except APDUError as e:
+            except APDUError:
                 pass
         return certs
 

--- a/ykman/piv.py
+++ b/ykman/piv.py
@@ -593,7 +593,7 @@ class PivController(object):
                     OBJ.PIVMAN_PROTECTED_DATA,
                     self._pivman_protected_data.get_bytes())
             except APDUError as e:
-                logger.debug("No pin provided, can't clear key..", exc_info=e)
+                logger.debug("No PIN provided, can't clear key..", exc_info=e)
 
     def get_pin_tries(self):
         """


### PR DESCRIPTION
I went through all `except` statements and added error logging where it seemed appropriate. My basic rules of thumb for when this was not needed were:

- If the `except` block (or the code following a `pass` statement) attempts to recover from the error
- In `except` block branches that raise new errors
- If the `except` block is on the CLI level and appropriate feedback is already given