### PR TITLE
Return number of retries on PIV PUK change failure

### DIFF
--- a/test/test_cli_commands_on_yubikey.py
+++ b/test/test_cli_commands_on_yubikey.py
@@ -477,8 +477,14 @@ class TestPIV(unittest.TestCase):
         ykman_cli('piv', 'change-pin', input='654321\n123456\n123456\n')
 
     def test_piv_change_puk(self):
-        ykman_cli('piv', 'change-puk', '-p', '12345678', '-n', '87654321')
-        ykman_cli('piv', 'change-puk', '-p', '87654321', '-n', '12345678')
+        o1 = ykman_cli('piv', 'change-puk', '-p', '12345678', '-n', '87654321')
+        self.assertIn('New PUK set.', o1)
+
+        o2 = ykman_cli('piv', 'change-puk', '-p', '87654321', '-n', '12345678')
+        self.assertIn('New PUK set.', o2)
+
+        with self.assertRaises(SystemExit):
+            ykman_cli('piv', 'change-puk', '-p', '87654321', '-n', '12345678')
 
     def test_piv_change_puk_prompt(self):
         ykman_cli('piv', 'change-puk', input='12345678\n87654321\n87654321\n')

--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -637,12 +637,14 @@ def change_puk(ctx, puk, new_puk):
         new_puk = click.prompt(
             'Enter your new PUK', default='', hide_input=True,
             show_default=False, confirmation_prompt=True)
-    try:
-        controller.change_puk(puk, new_puk)
-    except APDUError as e:
-        logger.error('Failed to change PUK', exc_info=e)
-        ctx.fail('Changing the PUK failed.')
-    click.echo('New PUK set.')
+
+    (success, retries) = controller.change_puk(puk, new_puk)
+
+    if success:
+        click.echo('New PUK set.')
+    else:
+        logger.debug('Failed to change PUK, %d tries left', retries)
+        ctx.fail('PUK change failed - %d tries left.' % retries)
 
 
 @piv.command('change-management-key')


### PR DESCRIPTION
So we don't have to expose `_get_puk_tries()` and spend retries on querying when the retry count needs to be displayed in yubikey-manager-qt, for example.