### PR TITLE
Log version after initializing logging

### DIFF
--- a/ykman/logging_setup.py
+++ b/ykman/logging_setup.py
@@ -28,6 +28,7 @@
 from __future__ import absolute_import
 
 import logging
+import ykman
 
 
 LOG_LEVELS = [logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR,
@@ -52,6 +53,10 @@ def setup(log_level_name, log_file=None):
         format='%(asctime)s %(levelname)s [%(name)s.%(funcName)s:%(lineno)d] %(message)s',  # noqa: E501
         level=log_level_value
     )
+
+    logger = logging.getLogger(__name__)
+    logger.info('Initialized logging for %s version: %s',
+                ykman.__name__, ykman.__version__)
 
 
 logging.disable(logging.CRITICAL * 2)

--- a/ykman/logging_setup.py
+++ b/ykman/logging_setup.py
@@ -27,13 +27,31 @@
 
 from __future__ import absolute_import
 
+import inspect
 import logging
+import os
+import subprocess
 import ykman
 
 
 LOG_LEVELS = [logging.DEBUG, logging.INFO, logging.WARNING, logging.ERROR,
               logging.CRITICAL]
 LOG_LEVEL_NAMES = [logging.getLevelName(lvl) for lvl in LOG_LEVELS]
+
+ykman_dir = os.path.dirname(dict(inspect.getmembers(ykman))['__file__'])
+git_version = None
+
+try:
+    git_describe_proc = subprocess.Popen(
+        ['git', '-C', ykman_dir,
+         'describe', '--tags', '--always', '--dirty=-DIRTY'],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE)
+    git_describe_proc.wait()
+    if git_describe_proc.returncode == 0:
+        git_version = git_describe_proc.stdout.read().decode('utf-8').strip()
+except Exception:
+    pass
 
 
 def setup(log_level_name, log_file=None):
@@ -57,6 +75,7 @@ def setup(log_level_name, log_file=None):
     logger = logging.getLogger(__name__)
     logger.info('Initialized logging for %s version: %s',
                 ykman.__name__, ykman.__version__)
+    logger.debug('Git version: %s', git_version)
 
 
 logging.disable(logging.CRITICAL * 2)


### PR DESCRIPTION
Mostly for de-confusion during development, but could possibly be useful for bug reports too. This carries through to the GUIs so this will print the ykman library version if it happens to be different from what you'd expect from the GUI version.