### PR TITLE
PIV: Move random mgmt key generation from module cli.piv to piv

### DIFF
--- a/test/on_yubikey/test_piv.py
+++ b/test/on_yubikey/test_piv.py
@@ -1,3 +1,4 @@
+import re
 import unittest
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend
@@ -181,13 +182,81 @@ class ManagementKey(PivTestCase):
             'Management key is stored on the YubiKey, protected by PIN',
             output)
 
-    def test_change_management_key_prompt(self):
-        ykman_cli('piv', 'change-management-key',
-                  input=old_new_new(DEFAULT_MANAGEMENT_KEY,
-                                    NON_DEFAULT_MANAGEMENT_KEY))
+        with self.assertRaises(SystemExit):
+            # Should fail - wrong current key
+            ykman_cli(
+                'piv', 'change-management-key', '-p', '-P', DEFAULT_PIN,
+                '-m', DEFAULT_MANAGEMENT_KEY)
+
+        # Should succeed - PIN as key
+        ykman_cli('piv', 'change-management-key', '-p', '-P', DEFAULT_PIN)
+
+    def test_change_management_key_protect_prompt(self):
+        ykman_cli('piv', 'change-management-key', '-p', '-P', DEFAULT_PIN,
+                  input=DEFAULT_MANAGEMENT_KEY)
+        output = ykman_cli('piv', 'info')
+        self.assertIn(
+            'Management key is stored on the YubiKey, protected by PIN',
+            output)
+
+        with self.assertRaises(SystemExit):
+            # Should fail - wrong current key
+            ykman_cli(
+                'piv', 'change-management-key', '-p', '-P', DEFAULT_PIN,
+                '-m', DEFAULT_MANAGEMENT_KEY)
+
+        # Should succeed - PIN as key
+        ykman_cli('piv', 'change-management-key', '-p', '-P', DEFAULT_PIN)
+
+    def test_change_management_key_no_protect_random(self):
+        output = ykman_cli(
+            'piv', 'change-management-key',
+            '-m', DEFAULT_MANAGEMENT_KEY)
+        self.assertRegex(
+            output, re.compile(
+                r'^Generated management key: [a-f0-9]{48}$', re.MULTILINE))
+
+        output = ykman_cli('piv', 'info')
+        self.assertNotIn('Management key is stored on the YubiKey', output)
+
+    def test_change_management_key_no_protect_arg(self):
+        output = ykman_cli(
+            'piv', 'change-management-key',
+            '-m', DEFAULT_MANAGEMENT_KEY,
+            '-n', NON_DEFAULT_MANAGEMENT_KEY)
+        self.assertEqual('', output)
+        output = ykman_cli('piv', 'info')
+        self.assertNotIn('Management key is stored on the YubiKey', output)
+
+        with self.assertRaises(SystemExit):
+            ykman_cli(
+                'piv', 'change-management-key',
+                '-m', DEFAULT_MANAGEMENT_KEY,
+                '-n', NON_DEFAULT_MANAGEMENT_KEY)
+
+        output = ykman_cli(
+            'piv', 'change-management-key',
+            '-m', NON_DEFAULT_MANAGEMENT_KEY,
+            '-n', DEFAULT_MANAGEMENT_KEY)
+        self.assertEqual('', output)
+
+    def test_change_management_key_no_protect_prompt(self):
+        output = ykman_cli('piv', 'change-management-key',
+                           input=old_new_new(DEFAULT_MANAGEMENT_KEY,
+                                             NON_DEFAULT_MANAGEMENT_KEY))
+        self.assertNotIn('Generated', output)
+        output = ykman_cli('piv', 'info')
+        self.assertNotIn('Management key is stored on the YubiKey', output)
+
+        with self.assertRaises(SystemExit):
+            ykman_cli('piv', 'change-management-key',
+                      input=old_new_new(DEFAULT_MANAGEMENT_KEY,
+                                        NON_DEFAULT_MANAGEMENT_KEY))
+
         ykman_cli('piv', 'change-management-key',
                   input=old_new_new(NON_DEFAULT_MANAGEMENT_KEY,
                                     DEFAULT_MANAGEMENT_KEY))
+        self.assertNotIn('Generated', output)
 
 
 class Pin(PivTestCase):

--- a/test/test_piv.py
+++ b/test/test_piv.py
@@ -9,6 +9,6 @@ class TestPivFunctions(unittest.TestCase):
     def test_generate_random_management_key(self):
         output1 = piv.generate_random_management_key()
         output2 = piv.generate_random_management_key()
-        self.assertIsInstance(output1, str)
-        self.assertIsInstance(output2, str)
+        self.assertIsInstance(output1, bytes)
+        self.assertIsInstance(output2, bytes)
         self.assertNotEqual(output1, output2)

--- a/test/test_piv.py
+++ b/test/test_piv.py
@@ -1,0 +1,14 @@
+#  vim: set fileencoding=utf-8 :
+
+import ykman.piv as piv
+import unittest
+
+
+class TestPivFunctions(unittest.TestCase):
+
+    def test_generate_random_management_key(self):
+        output1 = piv.generate_random_management_key()
+        output2 = piv.generate_random_management_key()
+        self.assertIsInstance(output1, str)
+        self.assertIsInstance(output2, str)
+        self.assertNotEqual(output1, output2)

--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -693,12 +693,7 @@ def change_management_key(
                     ' and will not be cleared if no PIN is provided. Continue?',
                     abort=True)
 
-    # If the key should be protected by PIN and no key is given,
-    # we generate a random key.
-    if protect and not new_management_key:
-        new_management_key = generate_random_management_key()
-
-    if not new_management_key:
+    if not new_management_key and not protect:
         if not force:
             new_management_key = click.prompt(
                 'Enter your new management key'
@@ -709,12 +704,15 @@ def change_management_key(
         if force or new_management_key == '':
             new_management_key = generate_random_management_key()
             click.echo(
-                'Generated management key: {}'.format(new_management_key))
+                'Generated management key: {}'.format(
+                    b2a_hex(new_management_key).decode('utf-8')))
 
-    try:
-        new_management_key = a2b_hex(new_management_key)
-    except Exception:
-        ctx.fail('New management key has the wrong format.')
+    if new_management_key and type(new_management_key) is not bytes:
+        try:
+            new_management_key = a2b_hex(new_management_key)
+        except Exception:
+            ctx.fail('New management key has the wrong format.')
+
     try:
         controller.set_mgm_key(
             new_management_key, touch=touch, store_on_device=protect)

--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -30,7 +30,7 @@ from __future__ import absolute_import
 from ..util import TRANSPORT, parse_private_key, parse_certificate
 from ..piv import (
     PivController, ALGO, OBJ, SW, SLOT, PIN_POLICY, TOUCH_POLICY,
-    DEFAULT_MANAGEMENT_KEY)
+    DEFAULT_MANAGEMENT_KEY, generate_random_management_key)
 from ..driver_ccid import APDUError, SW_APPLICATION_NOT_FOUND
 from .util import (
     click_force_option, click_skip_on_help, click_callback, prompt_for_touch)
@@ -696,7 +696,7 @@ def change_management_key(
     # If the key should be protected by PIN and no key is given,
     # we generate a random key.
     if protect and not new_management_key:
-        new_management_key = _generate_random_management_key()
+        new_management_key = generate_random_management_key()
 
     if not new_management_key:
         if not force:
@@ -707,7 +707,7 @@ def change_management_key(
                 hide_input=True, confirmation_prompt=True)
 
         if force or new_management_key == '':
-            new_management_key = _generate_random_management_key()
+            new_management_key = generate_random_management_key()
             click.echo(
                 'Generated management key: {}'.format(new_management_key))
 
@@ -753,10 +753,6 @@ def _prompt_management_key(
         return a2b_hex(management_key)
     except Exception:
         ctx.fail('Management key has the wrong format.')
-
-
-def _generate_random_management_key():
-    return b2a_hex(os.urandom(24)).decode()
 
 
 def _prompt_pin(ctx, prompt='Enter PIN'):

--- a/ykman/piv.py
+++ b/ykman/piv.py
@@ -32,6 +32,7 @@ from .driver_ccid import APDUError, SW_OK, SW_APPLICATION_NOT_FOUND
 from .util import (
     AID, Tlv, parse_tlvs,
     ensure_not_cve201715361_vulnerable_firmware_version)
+from binascii import b2a_hex
 from collections import namedtuple
 from cryptography import x509
 from cryptography.utils import int_to_bytes, int_from_bytes
@@ -356,6 +357,10 @@ _decrypt_len_conditions = {
 def _derive_key(pin, salt):
     kdf = PBKDF2HMAC(hashes.SHA1(), 24, salt, 10000, default_backend())
     return kdf.derive(pin.encode('utf-8'))
+
+
+def generate_random_management_key():
+    return b2a_hex(os.urandom(24)).decode()
 
 
 class PivmanData(object):


### PR DESCRIPTION
This way it'll be less weird to reuse it in other non-CLI code.