### PR TITLE
Fix PIV cert generation when sign requires PIN

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+* Version 0.6.1 (unreleased)
+ ** Bug fixes:
+  *** PIV: Signing operations with PIN policy ALWAYS now require only one preceding call to `PivController.verify()`, instead of two. As a consequence, signing CLI operations with PIN policy ALWAYS no longer fail if the YubiKey has a management key protected by PIN.
+
 * Version 0.6.0 (released 2018-02-09)
  ** OpenPGP: Expose remaining PIN retries in info command and API.
  ** CCID: Only try YubiKey smart card readers by default.

--- a/test/on_yubikey/test_cli_piv.py
+++ b/test/on_yubikey/test_cli_piv.py
@@ -163,13 +163,14 @@ class GenerateSelfSigned_NonDefaultMgmKey(PivTestCase):
 
     def _test_generate_self_signed(self, slot):
         for algo in ('ECCP256', 'RSA1024'):
-            ykman_cli(
+            pubkey_output = ykman_cli(
                 'piv', 'generate-key', slot, '-a', algo, '-m',
-                NON_DEFAULT_MANAGEMENT_KEY, '/tmp/test-pub-key.pem')
+                NON_DEFAULT_MANAGEMENT_KEY, '-')
             ykman_cli(
                 'piv', 'generate-certificate', slot, '-m',
-                NON_DEFAULT_MANAGEMENT_KEY, '/tmp/test-pub-key.pem',
-                '-s', 'subject-' + algo, '-P', DEFAULT_PIN)
+                NON_DEFAULT_MANAGEMENT_KEY,
+                '-s', 'subject-' + algo, '-P', DEFAULT_PIN,
+                '-', input=pubkey_output)
             output = ykman_cli('piv', 'export-certificate', slot, '-')
             cert = x509.load_pem_x509_certificate(output.encode(),
                                                   default_backend())
@@ -203,12 +204,13 @@ class GenerateSelfSigned_ProtectedMgmKey(PivTestCase):
 
     def _test_generate_self_signed(self, slot):
         for algo in ('ECCP256', 'RSA1024'):
-            ykman_cli(
+            pubkey_output = ykman_cli(
                 'piv', 'generate-key', slot, '-a', algo, '-P', DEFAULT_PIN,
-                '/tmp/test-pub-key.pem')
+                '-')
             ykman_cli(
                 'piv', 'generate-certificate', slot, '-P', DEFAULT_PIN,
-                '/tmp/test-pub-key.pem', '-s', 'subject-' + algo)
+                '-s', 'subject-' + algo,
+                '-', input=pubkey_output)
             output = ykman_cli('piv', 'export-certificate', slot, '-')
             cert = x509.load_pem_x509_certificate(output.encode(),
                                                   default_backend())

--- a/test/on_yubikey/test_cli_piv.py
+++ b/test/on_yubikey/test_cli_piv.py
@@ -193,6 +193,34 @@ class GenerateSelfSigned_NonDefaultMgmKey(PivTestCase):
     def test_generate_self_signed_slot_9e(self):
         self._test_generate_self_signed('9e')
 
+    def _test_generate_csr(self, slot):
+        for algo in ('ECCP256', 'RSA1024'):
+            subject_input = 'subject-' + algo
+            pubkey_output = ykman_cli(
+                'piv', 'generate-key', slot, '-a', algo,
+                '-m', NON_DEFAULT_MANAGEMENT_KEY, '-')
+            csr_output = ykman_cli(
+                'piv', 'generate-csr', slot, '-P', DEFAULT_PIN,
+                '-', '-', '-s', subject_input, input=pubkey_output)
+            csr = x509.load_pem_x509_csr(csr_output.encode('utf-8'),
+                                         default_backend())
+            subject_output = csr.subject.get_attributes_for_oid(
+                x509.NameOID.COMMON_NAME)[0].value
+
+            self.assertEqual(subject_input, subject_output)
+
+    def test_generate_csr_slot_9a(self):
+        self._test_generate_csr('9a')
+
+    def test_generate_csr_slot_9c(self):
+        self._test_generate_csr('9c')
+
+    def test_generate_csr_slot_9d(self):
+        self._test_generate_csr('9d')
+
+    def test_generate_csr_slot_9e(self):
+        self._test_generate_csr('9e')
+
 
 class GenerateSelfSigned_ProtectedMgmKey(PivTestCase):
 
@@ -232,6 +260,34 @@ class GenerateSelfSigned_ProtectedMgmKey(PivTestCase):
 
     def test_generate_self_signed_slot_9e(self):
         self._test_generate_self_signed('9e')
+
+    def _test_generate_csr(self, slot):
+        for algo in ('ECCP256', 'RSA1024'):
+            subject_input = 'subject-' + algo
+            pubkey_output = ykman_cli(
+                'piv', 'generate-key', slot, '-a', algo, '-P', DEFAULT_PIN,
+                '-')
+            csr_output = ykman_cli(
+                'piv', 'generate-csr', slot, '-P', DEFAULT_PIN,
+                '-', '-', '-s', subject_input, input=pubkey_output)
+            csr = x509.load_pem_x509_csr(csr_output.encode('utf-8'),
+                                         default_backend())
+            subject_output = csr.subject.get_attributes_for_oid(
+                x509.NameOID.COMMON_NAME)[0].value
+
+            self.assertEqual(subject_input, subject_output)
+
+    def test_generate_csr_slot_9a(self):
+        self._test_generate_csr('9a')
+
+    def test_generate_csr_slot_9c(self):
+        self._test_generate_csr('9c')
+
+    def test_generate_csr_slot_9d(self):
+        self._test_generate_csr('9d')
+
+    def test_generate_csr_slot_9e(self):
+        self._test_generate_csr('9e')
 
 
 class ManagementKey(PivTestCase):

--- a/test/on_yubikey/test_cli_piv.py
+++ b/test/on_yubikey/test_cli_piv.py
@@ -152,20 +152,23 @@ class KeyManagement(PivTestCase):
         self.assertIn('BEGIN CERTIFICATE', output)
 
 
-class GenerateSelfSigned_DefaultMgmKey(PivTestCase):
+class GenerateSelfSigned_NonDefaultMgmKey(PivTestCase):
 
     @classmethod
     def setUpClass(cls):
         ykman_cli('piv', 'reset', '-f')
+        ykman_cli('piv', 'change-management-key', '-P', DEFAULT_PIN,
+                  '-m', DEFAULT_MANAGEMENT_KEY,
+                  '-n', NON_DEFAULT_MANAGEMENT_KEY)
 
     def _test_generate_self_signed(self, slot):
         for algo in ('ECCP256', 'RSA1024'):
             ykman_cli(
                 'piv', 'generate-key', slot, '-a', algo, '-m',
-                DEFAULT_MANAGEMENT_KEY, '/tmp/test-pub-key.pem')
+                NON_DEFAULT_MANAGEMENT_KEY, '/tmp/test-pub-key.pem')
             ykman_cli(
                 'piv', 'generate-certificate', slot, '-m',
-                DEFAULT_MANAGEMENT_KEY, '/tmp/test-pub-key.pem',
+                NON_DEFAULT_MANAGEMENT_KEY, '/tmp/test-pub-key.pem',
                 '-s', 'subject-' + algo, '-P', DEFAULT_PIN)
             output = ykman_cli('piv', 'export-certificate', slot, '-')
             cert = x509.load_pem_x509_certificate(output.encode(),

--- a/test/on_yubikey/test_piv.py
+++ b/test/on_yubikey/test_piv.py
@@ -81,15 +81,15 @@ class KeyManagement(PivTestCase):
             controller = PivController(dev.driver)
             controller.reset()
 
-    def generate_key(self):
+    def generate_key(self, slot):
         self.controller.authenticate(DEFAULT_MANAGEMENT_KEY)
         public_key = self.controller.generate_key(
-            SLOT.AUTHENTICATION, ALGO.ECCP256, touch_policy=TOUCH_POLICY.NEVER)
+            slot, ALGO.ECCP256, touch_policy=TOUCH_POLICY.NEVER)
         self.reconnect()
         return public_key
 
     def test_delete_certificate_requires_authentication(self):
-        self.generate_key()
+        self.generate_key(SLOT.AUTHENTICATION)
 
         with self.assertRaises(APDUError):
             self.controller.delete_certificate(SLOT.AUTHENTICATION)
@@ -98,7 +98,7 @@ class KeyManagement(PivTestCase):
         self.controller.delete_certificate(SLOT.AUTHENTICATION)
 
     def test_generate_csr_works(self):
-        public_key = self.generate_key()
+        public_key = self.generate_key(SLOT.AUTHENTICATION)
         if get_version() < (4, 0, 0):
             # NEO always has PIN policy "ONCE"
             self.controller.verify(DEFAULT_PIN)
@@ -121,7 +121,7 @@ class KeyManagement(PivTestCase):
         )
 
     def test_generate_self_signed_certificate_requires_authentication(self):
-        public_key = self.generate_key()
+        public_key = self.generate_key(SLOT.AUTHENTICATION)
         if get_version() < (4, 0, 0):
             # NEO always has PIN policy "ONCE"
             self.controller.verify(DEFAULT_PIN)
@@ -136,7 +136,7 @@ class KeyManagement(PivTestCase):
             SLOT.AUTHENTICATION, public_key, 'alice', now(), now())
 
     def _test_generate_self_signed_certificate(self, slot):
-        public_key = self.generate_key()
+        public_key = self.generate_key(slot)
         self.controller.authenticate(DEFAULT_MANAGEMENT_KEY)
         self.controller.verify(DEFAULT_PIN)
         self.controller.generate_self_signed_certificate(

--- a/ykman/piv.py
+++ b/ykman/piv.py
@@ -501,10 +501,12 @@ class PivController(object):
         if self.has_derived_key and not self._authenticated:
             self.authenticate(
                 _derive_key(pin, self._pivman_data.salt), touch_callback)
+            self.verify(pin, touch_callback)
 
         if self.has_stored_key and not self._authenticated:
             self._init_pivman_protected()
             self.authenticate(self._pivman_protected_data.key, touch_callback)
+            self.verify(pin, touch_callback)
 
     def change_pin(self, old_pin, new_pin):
         self.send_cmd(INS.CHANGE_REFERENCE, 0, PIN,


### PR DESCRIPTION
`PivController.verify()` now calls itself again if it also called `authenticate()` to unlock a protected management key. This means that a following `sign()` call with PIN policy ALWAYS will no longer require an additional preceding `verify()` call, whereas the `authenticate()` call would previously consume the "verifiedness" required by the ALWAYS policy.