### PR TITLE
Fix destructive tests in Python 2

### DIFF
--- a/test/on_yubikey/test_piv.py
+++ b/test/on_yubikey/test_piv.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import datetime
 import unittest
 from binascii import a2b_hex
@@ -96,7 +98,7 @@ class KeyManagement(PivTestCase):
 
         self.controller.verify(DEFAULT_PIN)
         csr = self.controller.generate_certificate_signing_request(
-            SLOT.AUTHENTICATION, public_key, u'alice')
+            SLOT.AUTHENTICATION, public_key, 'alice')
 
         self.assertEqual(
             csr.public_key().public_bytes(
@@ -119,19 +121,19 @@ class KeyManagement(PivTestCase):
 
         with self.assertRaises(APDUError):
             self.controller.generate_self_signed_certificate(
-                SLOT.AUTHENTICATION, public_key, u'alice', now(), now())
+                SLOT.AUTHENTICATION, public_key, 'alice', now(), now())
 
         self.controller.authenticate(DEFAULT_MANAGEMENT_KEY)
         self.controller.verify(DEFAULT_PIN)
         self.controller.generate_self_signed_certificate(
-            SLOT.AUTHENTICATION, public_key, u'alice', now(), now())
+            SLOT.AUTHENTICATION, public_key, 'alice', now(), now())
 
     def _test_generate_self_signed_certificate(self, slot):
         public_key = self.generate_key(slot)
         self.controller.authenticate(DEFAULT_MANAGEMENT_KEY)
         self.controller.verify(DEFAULT_PIN)
         self.controller.generate_self_signed_certificate(
-            slot, public_key, u'alice', now(), now())
+            slot, public_key, 'alice', now(), now())
 
         cert = self.controller.read_certificate(slot)
 

--- a/test/on_yubikey/test_piv.py
+++ b/test/on_yubikey/test_piv.py
@@ -8,7 +8,7 @@ from ykman.piv import (ALGO, PIN_POLICY, PivController, SLOT, TOUCH_POLICY)
 from ykman.util import TRANSPORT, parse_certificate, parse_private_key
 from .util import (
     DestructiveYubikeyTestCase, missing_mode, open_device, get_version)
-from ..util import open_file
+from ..util import a2b_hex_if_text, open_file
 
 
 DEFAULT_PIN = '123456'
@@ -46,25 +46,21 @@ class PivTestCase(DestructiveYubikeyTestCase):
         self.dev.driver.close()
 
     def assertMgmKeyIs(self, key):
-        if type(key) is str:
-            key = a2b_hex(key)
+        key = a2b_hex_if_text(key)
         self.controller.authenticate(key)
 
     def assertMgmKeyIsNot(self, key):
-        if type(key) is str:
-            key = a2b_hex(key)
+        key = a2b_hex_if_text(key)
 
         with self.assertRaises(APDUError):
             self.controller.authenticate(key)
 
     def assertStoredMgmKeyEquals(self, key):
-        if type(key) is str:
-            key = a2b_hex(key)
+        key = a2b_hex_if_text(key)
         self.assertEqual(self.controller._pivman_protected_data.key, key)
 
     def assertStoredMgmKeyNotEquals(self, key):
-        if type(key) is str:
-            key = a2b_hex(key)
+        key = a2b_hex_if_text(key)
         self.assertNotEqual(self.controller._pivman_protected_data.key, key)
 
     def reconnect(self):

--- a/test/on_yubikey/test_piv.py
+++ b/test/on_yubikey/test_piv.py
@@ -230,8 +230,10 @@ class ManagementKeyReadOnly(PivTestCase):
 
     def test_reset_while_verified_throws_nice_ValueError(self):
         self.controller.verify(DEFAULT_PIN)
-        with self.assertRaisesRegex(ValueError, '^Failed reading remaining'):
+        with self.assertRaises(ValueError) as cm:
             self.controller.reset()
+        self.assertRegexpMatches(str(cm.exception),
+                                 '^Failed reading remaining')
 
     def test_set_mgm_key_does_not_change_key_if_not_authenticated(self):
         with self.assertRaises(APDUError):

--- a/test/on_yubikey/test_piv.py
+++ b/test/on_yubikey/test_piv.py
@@ -8,7 +8,7 @@ from ykman.piv import (ALGO, PIN_POLICY, PivController, SLOT, TOUCH_POLICY)
 from ykman.util import TRANSPORT, parse_certificate, parse_private_key
 from .util import (
     DestructiveYubikeyTestCase, missing_mode, open_device, get_version)
-from ..util import a2b_hex_if_text, open_file
+from ..util import open_file
 
 
 DEFAULT_PIN = '123456'
@@ -46,21 +46,16 @@ class PivTestCase(DestructiveYubikeyTestCase):
         self.dev.driver.close()
 
     def assertMgmKeyIs(self, key):
-        key = a2b_hex_if_text(key)
         self.controller.authenticate(key)
 
     def assertMgmKeyIsNot(self, key):
-        key = a2b_hex_if_text(key)
-
         with self.assertRaises(APDUError):
             self.controller.authenticate(key)
 
     def assertStoredMgmKeyEquals(self, key):
-        key = a2b_hex_if_text(key)
         self.assertEqual(self.controller._pivman_protected_data.key, key)
 
     def assertStoredMgmKeyNotEquals(self, key):
-        key = a2b_hex_if_text(key)
         self.assertNotEqual(self.controller._pivman_protected_data.key, key)
 
     def reconnect(self):

--- a/test/on_yubikey/test_piv.py
+++ b/test/on_yubikey/test_piv.py
@@ -101,7 +101,7 @@ class KeyManagement(PivTestCase):
 
         self.controller.verify(DEFAULT_PIN)
         csr = self.controller.generate_certificate_signing_request(
-            SLOT.AUTHENTICATION, public_key, 'alice')
+            SLOT.AUTHENTICATION, public_key, u'alice')
 
         self.assertEqual(
             csr.public_key().public_bytes(
@@ -124,19 +124,19 @@ class KeyManagement(PivTestCase):
 
         with self.assertRaises(APDUError):
             self.controller.generate_self_signed_certificate(
-                SLOT.AUTHENTICATION, public_key, 'alice', now(), now())
+                SLOT.AUTHENTICATION, public_key, u'alice', now(), now())
 
         self.controller.authenticate(DEFAULT_MANAGEMENT_KEY)
         self.controller.verify(DEFAULT_PIN)
         self.controller.generate_self_signed_certificate(
-            SLOT.AUTHENTICATION, public_key, 'alice', now(), now())
+            SLOT.AUTHENTICATION, public_key, u'alice', now(), now())
 
     def _test_generate_self_signed_certificate(self, slot):
         public_key = self.generate_key(slot)
         self.controller.authenticate(DEFAULT_MANAGEMENT_KEY)
         self.controller.verify(DEFAULT_PIN)
         self.controller.generate_self_signed_certificate(
-            slot, public_key, 'alice', now(), now())
+            slot, public_key, u'alice', now(), now())
 
         cert = self.controller.read_certificate(slot)
 

--- a/test/util.py
+++ b/test/util.py
@@ -1,6 +1,8 @@
+from binascii import a2b_hex
 from click.testing import CliRunner
 from ykman.cli.__main__ import cli
 import os
+import sys
 
 
 PKG_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -16,3 +18,16 @@ def ykman_cli(*argv, **kwargs):
     if result.exit_code != 0:
         raise result.exception
     return result.output
+
+
+def a2b_hex_if_text(data):
+    if sys.version_info < (3, 0):
+        if len(data) > 0:
+            d = data[0]
+            if (d >= '0' and d <= '9') or (d >= 'a' and d <= 'f'):
+                return a2b_hex(data)
+    else:
+        if type(data) is str:
+            return a2b_hex(data)
+
+    return data

--- a/test/util.py
+++ b/test/util.py
@@ -1,8 +1,6 @@
-from binascii import a2b_hex
 from click.testing import CliRunner
 from ykman.cli.__main__ import cli
 import os
-import sys
 
 
 PKG_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -18,16 +16,3 @@ def ykman_cli(*argv, **kwargs):
     if result.exit_code != 0:
         raise result.exception
     return result.output
-
-
-def a2b_hex_if_text(data):
-    if sys.version_info < (3, 0):
-        if len(data) > 0:
-            d = data[0]
-            if (d >= '0' and d <= '9') or (d >= 'a' and d <= 'f'):
-                return a2b_hex(data)
-    else:
-        if type(data) is str:
-            return a2b_hex(data)
-
-    return data


### PR DESCRIPTION
- Remove unused type conversions that didn't work in Python 2
- Pass `u''` strings to make `x509.NameAttribute` happy in Python 2
- Don't use `assertRaisesRegex` which was added in Python 3