### PR TITLE
Make all non-short options case insensitive

### DIFF
--- a/test/on_yubikey/test_cli_config.py
+++ b/test/on_yubikey/test_cli_config.py
@@ -138,6 +138,11 @@ class TestConfigNFC(DestructiveYubikeyTestCase):
             ykman_cli(
                 'config', 'nfc', '--enable-all', '--disable-all', 'FIDO2', '-f')
 
+    def test_case_insensitive(self):
+        ykman_cli('config', 'nfc', '--LIST')  # Assume no exception
+        with self.assertRaises(SystemExit):
+            ykman_cli('config', 'nfc', '-L')  # -l is sensitive
+
 
 @unittest.skipIf(not can_write_config(), 'Device can not write config')
 class TestConfigLockCode(DestructiveYubikeyTestCase):

--- a/ykman/cli/__main__.py
+++ b/ykman/cli/__main__.py
@@ -52,9 +52,15 @@ import sys
 logger = logging.getLogger(__name__)
 
 
+def _normalize_token(val):
+    #  Non short options should be case insensitive.
+    return val.upper() if len(val) > 1 else val
+
+
 CLICK_CONTEXT_SETTINGS = dict(
     help_option_names=['-h', '--help'],
-    max_content_width=999
+    max_content_width=999,
+    token_normalize_func=_normalize_token,
 )
 
 


### PR DESCRIPTION
The idea is that all options that are not short-options should be case insensitive. This is done using the [token_normalize_func](http://click.pocoo.org/6/api/#click.Context.token_normalize_func), as suggested in [this thread](https://github.com/pallets/click/issues/569).

The alternative is to normalize all options (not only those with a >1 length), but then we can't have options like `-p` and `-P` have different meanings.