### PR TITLE
Add UpperCaseChoice for case insensitive choices

### DIFF
--- a/ykman/cli/__main__.py
+++ b/ykman/cli/__main__.py
@@ -34,7 +34,7 @@ from ..native.pyusb import get_usb_backend_version
 from ..driver_otp import libversion as ykpers_version
 from ..descriptor import (get_descriptors, list_devices, open_device,
                           FailedOpeningDeviceException)
-from .util import click_skip_on_help
+from .util import click_skip_on_help, UpperCaseChoice
 from .info import info
 from .mode import mode
 from .otp import otp
@@ -124,7 +124,7 @@ def _run_cmd_for_single(ctx, cmd, transports):
               expose_value=False, is_eager=True)
 @click.option('-d', '--device', type=int, metavar='SERIAL')
 @click.option('-l', '--log-level', default=None,
-              type=click.Choice(ykman.logging_setup.LOG_LEVEL_NAMES),
+              type=UpperCaseChoice(ykman.logging_setup.LOG_LEVEL_NAMES),
               help='Enable logging at given verbosity level',
               )
 @click.option('--log-file', default=None,

--- a/ykman/cli/config.py
+++ b/ykman/cli/config.py
@@ -27,7 +27,7 @@
 
 from __future__ import absolute_import
 
-from .util import click_skip_on_help, click_force_option
+from .util import click_skip_on_help, click_force_option, UpperCaseChoice
 from ..device import device_config, FLAGS
 from ..util import APPLICATION
 import logging
@@ -145,10 +145,10 @@ def set_lock_code(ctx, lock_code, new_lock_code, clear):
 @click.pass_context
 @click_force_option
 @click.option(
-    '-e', '--enable', multiple=True, type=click.Choice(
+    '-e', '--enable', multiple=True, type=UpperCaseChoice(
         APPLICATION.__members__.keys()), help='Enable applications.')
 @click.option(
-    '-d', '--disable', multiple=True, type=click.Choice(
+    '-d', '--disable', multiple=True, type=UpperCaseChoice(
         APPLICATION.__members__.keys()), help='Disable applications.')
 @click.option('-l', '--list', is_flag=True, help='List enabled applications.')
 @click.option(
@@ -266,10 +266,10 @@ def usb(
 @click.pass_context
 @click_force_option
 @click.option(
-    '-e', '--enable', multiple=True, type=click.Choice(
+    '-e', '--enable', multiple=True, type=UpperCaseChoice(
         APPLICATION.__members__.keys()), help='Enable applications.')
 @click.option(
-    '-d', '--disable', multiple=True, type=click.Choice(
+    '-d', '--disable', multiple=True, type=UpperCaseChoice(
         APPLICATION.__members__.keys()), help='Disable applications.')
 @click.option(
     '-a', '--enable-all', is_flag=True, help='Enable all applications.')

--- a/ykman/cli/oath.py
+++ b/ykman/cli/oath.py
@@ -33,7 +33,7 @@ from binascii import b2a_hex, a2b_hex
 from .util import (
     click_force_option, click_skip_on_help,
     click_callback, click_parse_b32_key,
-    prompt_for_touch)
+    prompt_for_touch, UpperCaseChoice)
 from ..driver_ccid import APDUError,  SW_APPLICATION_NOT_FOUND
 from ..util import TRANSPORT, parse_b32_key
 from ..oath import OathController, SW, CredentialData, OATH_TYPE, ALGO
@@ -147,14 +147,14 @@ def reset(ctx):
 @click.argument('name')
 @click.argument('secret', callback=click_parse_b32_key, required=False)
 @click.option(
-    '-o', '--oath-type', type=click.Choice(['TOTP', 'HOTP']), default='TOTP',
+    '-o', '--oath-type', type=UpperCaseChoice(['TOTP', 'HOTP']), default='TOTP',
     help='Time-based (TOTP) or counter-based'
     ' (HOTP) credential.', show_default=True)
 @click.option(
     '-d', '--digits', type=click.Choice(['6', '7', '8']), default='6',
     help='Number of digits in generated code.', show_default=True)
 @click.option(
-    '-a', '--algorithm', type=click.Choice(['SHA1', 'SHA256', 'SHA512']),
+    '-a', '--algorithm', type=UpperCaseChoice(['SHA1', 'SHA256', 'SHA512']),
     default='SHA1', help='Algorithm to use for '
     'code generation.', show_default=True)
 @click.option(

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import
 
 from .util import (
     click_force_option, click_callback, click_parse_b32_key,
-    click_skip_on_help, prompt_for_touch)
+    click_skip_on_help, prompt_for_touch, UpperCaseChoice)
 from ..util import (
     TRANSPORT, generate_static_pw, modhex_decode,
     modhex_encode, parse_key, parse_b32_key)
@@ -283,7 +283,7 @@ def yubiotp(ctx, slot, public_id, private_id, key, no_enter, force,
     '-l', '--length', type=click.IntRange(1, 38),
     help='Length of generated password.')
 @click.option(
-    '-k', '--keyboard-layout', type=click.Choice(
+    '-k', '--keyboard-layout', type=UpperCaseChoice(
             [l.name for l in KEYBOARD_LAYOUT]),
     default='MODHEX', show_default=True,
     help='Keyboard layout to use for the static password.')

--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -33,7 +33,8 @@ from ..piv import (
     DEFAULT_MANAGEMENT_KEY, generate_random_management_key)
 from ..driver_ccid import APDUError, SW_APPLICATION_NOT_FOUND
 from .util import (
-    click_force_option, click_skip_on_help, click_callback, prompt_for_touch)
+    click_force_option, click_skip_on_help, click_callback, prompt_for_touch,
+    UpperCaseChoice)
 from cryptography import x509
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
@@ -86,13 +87,14 @@ click_pin_option = click.option(
     '-P', '--pin', help='PIN code.')
 click_format_option = click.option(
     '-F', '--format',
-    type=click.Choice(['PEM', 'DER']), default='PEM', show_default=True,
+    type=UpperCaseChoice(['PEM', 'DER']), default='PEM', show_default=True,
     help='Encoding format.', callback=click_parse_format)
 click_pin_policy_option = click.option(
-    '--pin-policy', type=click.Choice(['DEFAULT', 'NEVER', 'ONCE', 'ALWAYS']),
+    '--pin-policy',
+    type=UpperCaseChoice(['DEFAULT', 'NEVER', 'ONCE', 'ALWAYS']),
     help='PIN policy for slot.')
 click_touch_policy_option = click.option(
-    '--touch-policy', type=click.Choice(
+    '--touch-policy', type=UpperCaseChoice(
         ['DEFAULT', 'NEVER', 'ALWAYS', 'CACHED']),
     help='Touch policy for slot.')
 
@@ -193,7 +195,7 @@ def reset(ctx):
 @click_pin_option
 @click.option(
     '-a', '--algorithm', help='Algorithm to use in key generation.',
-    type=click.Choice(
+    type=UpperCaseChoice(
         ['RSA1024', 'RSA2048', 'ECCP256', 'ECCP384']), default='RSA2048',
     show_default=True)
 @click_format_option

--- a/ykman/cli/util.py
+++ b/ykman/cli/util.py
@@ -36,6 +36,22 @@ click_force_option = click.option('-f', '--force', is_flag=True,
                                   help='Confirm the action without prompting.')
 
 
+class UpperCaseChoice(click.Choice):
+    """
+    Support lowercase option values for uppercase options.
+    Does not support token normalization.
+    """
+    def __init__(self, choices):
+        click.Choice.__init__(self, choices)
+
+    def convert(self, value, param, ctx):
+        if value.upper() in self.choices:
+            return value.upper()
+        self.fail(
+            'invalid choice: %s. (choose from %s)' % (
+                value, ', '.join(self.choices)), param, ctx)
+
+
 def click_callback(invoke_on_missing=False):
     def wrap(f):
         @functools.wraps(f)


### PR DESCRIPTION
Alternative solution to #104 

- Introduce UpperCaseChoice, a subclass of click.Choice
- Use it for options where it makes sense