### PR TITLE
otp: try reading config twice if timeout

### DIFF
--- a/test/on_yubikey/test_interfaces.py
+++ b/test/on_yubikey/test_interfaces.py
@@ -1,0 +1,19 @@
+from .util import DestructiveYubikeyTestCase
+from ykman import driver_fido, driver_otp, driver_ccid
+
+
+class TestInterfaces(DestructiveYubikeyTestCase):
+
+    def test_switch_interfaces(self):
+        next(driver_fido.open_devices()).read_config()
+        next(driver_otp.open_devices()).read_config()
+        next(driver_fido.open_devices()).read_config()
+        next(driver_ccid.open_devices()).read_config()
+        next(driver_otp.open_devices()).read_config()
+        next(driver_ccid.open_devices()).read_config()
+        next(driver_otp.open_devices()).read_config()
+        next(driver_fido.open_devices()).read_config()
+        next(driver_ccid.open_devices()).read_config()
+        next(driver_fido.open_devices()).read_config()
+        next(driver_ccid.open_devices()).read_config()
+        next(driver_otp.open_devices()).read_config()


### PR DESCRIPTION
Using the OTP interface directly after using FIDO might result in a timeout. If this happens, wait 3 seconds and try again.

To reproduce the error that this fixes:

```
from ykman import driver_fido, driver_otp
next(driver_fido.open_devices()).read_config()
next(driver_otp.open_devices()).read_config()
```