### PR TITLE
Don't print re-insert prompt if --force is given to fido reset

### DIFF
--- a/ykman/cli/fido.py
+++ b/ykman/cli/fido.py
@@ -165,9 +165,9 @@ def reset(ctx, force):
     The reset must be triggered immediately after the YubiKey is
     inserted, and requires a touch on the YubiKey.
     """
-    click.echo('Remove and re-insert your YubiKey to perform the reset...')
-
     def prompt_re_insert_key():
+        click.echo('Remove and re-insert your YubiKey to perform the reset...')
+
         removed = False
         while True:
             sleep(0.1)


### PR DESCRIPTION
This code path instead fails if the reset window has closed, so don't print the message in this case.