### PR TITLE
Don't validate old PIN in change_pin

### DIFF
--- a/ykman/cli/fido.py
+++ b/ykman/cli/fido.py
@@ -101,7 +101,6 @@ def set_pin(ctx, pin, new_pin):
                     show_default=False)
 
     def change_pin(pin, new_pin):
-        fail_if_not_valid(ctx, pin)
         fail_if_not_valid(ctx, new_pin)
         try:
             controller.change_pin(old_pin=pin, new_pin=new_pin)


### PR DESCRIPTION
The old PIN is by definition already set, so there's no point in validating it.

This change also lets us reuse this code for setting the initial PIN for FIPS U2F - since there's only one SET_PIN command (for both change and initial set) and there's no command to check if a PIN is already set, we'll simply use change_pin and pass an empty old PIN in that case. This removed validation would prevent passing an empty old PIN.