### PR TITLE
Refuse set/delete access code on firmware versions 4.3.2 - 4.3.5

### DIFF
--- a/test/on_yubikey/test_cli_otp.py
+++ b/test/on_yubikey/test_cli_otp.py
@@ -124,6 +124,16 @@ class TestSlotProgramming(DestructiveYubikeyTestCase):
     def tearDown(self):
         ykman_cli('otp', 'delete', '2', '-f')
 
+    def _require_version_between(self, min_exclusive, max_exclusive):
+        if not min_exclusive < get_version() < max_exclusive:
+            self.skipTest('Requires version {} < v < {}'.format(
+                min_exclusive, max_exclusive))
+
+    def _require_version_not_between(self, min_exclusive, max_exclusive):
+        if min_exclusive < get_version() < max_exclusive:
+            self.skipTest('Requires version not {} < v < {}'.format(
+                min_exclusive, max_exclusive))
+
     def test_ykman_program_otp_slot_2(self):
         ykman_cli(
             'otp', 'yubiotp', '2', '--public-id', 'vvccccfiluij',
@@ -269,9 +279,9 @@ class TestSlotProgramming(DestructiveYubikeyTestCase):
         status = ykman_cli('otp', 'info')
         self.assertIn('Slot 2: empty', status)
 
-    @unittest.skipIf(not (4, 3, 1) < get_version() < (4, 3, 6),
-                     'Applicable only to YubiKey 4.3.4 and 4.3.5')
     def test_update_access_code_fails_on_yk_432_to_435(self):
+        self._require_version_between((4, 3, 1), (4, 3, 6))
+
         ykman_cli('otp', 'static', '2', '--generate', '--length', '10')
 
         self._check_slot_2_programmed()
@@ -292,9 +302,9 @@ class TestSlotProgramming(DestructiveYubikeyTestCase):
 
         ykman_cli('otp', '--access-code', '111111111111', 'delete', '2', '-f')
 
-    @unittest.skipIf(not (4, 3, 1) < get_version() < (4, 3, 6),
-                     'Applicable only to YubiKey 4.3.2 to 4.3.5')
     def test_delete_access_code_fails_on_yk_432_to_435(self):
+        self._require_version_between((4, 3, 1), (4, 3, 6))
+
         ykman_cli('otp', '--access-code', '111111111111', 'static', '2',
                   '--generate', '--length', '10')
 
@@ -309,9 +319,9 @@ class TestSlotProgramming(DestructiveYubikeyTestCase):
 
         ykman_cli('otp', '--access-code', '111111111111', 'delete', '2', '-f')
 
-    @unittest.skipIf((4, 3, 1) < get_version() < (4, 3, 6),
-                     'Update access code fails on YubiKey 4.3.2 to 4.3.5')
     def test_update_access_code_slot_2(self):
+        self._require_version_not_between((4, 3, 1), (4, 3, 6))
+
         ykman_cli('otp', 'static', '2', '--generate', '--length', '10')
 
         self._check_slot_2_programmed()
@@ -327,9 +337,9 @@ class TestSlotProgramming(DestructiveYubikeyTestCase):
 
         ykman_cli('otp', 'delete', '2', '-f')
 
-    @unittest.skipIf((4, 3, 1) < get_version() < (4, 3, 6),
-                     'Update access code fails on YubiKey 4.3.2 to 4.3.5')
     def test_update_access_code_prompt_slot_2(self):
+        self._require_version_not_between((4, 3, 1), (4, 3, 6))
+
         ykman_cli('otp', 'static', '2', '--generate', '--length', '10')
 
         self._check_slot_2_programmed()
@@ -345,9 +355,9 @@ class TestSlotProgramming(DestructiveYubikeyTestCase):
 
         ykman_cli('otp', 'delete', '2', '-f')
 
-    @unittest.skipIf((4, 3, 1) < get_version() < (4, 3, 6),
-                     'Update access code fails on YubiKey 4.3.2 to 4.3.5')
     def test_new_access_code_conflicts_with_delete_access_code(self):
+        self._require_version_not_between((4, 3, 1), (4, 3, 6))
+
         ykman_cli('otp', 'static', '2', '--generate', '--length', '10')
 
         self._check_slot_2_programmed()

--- a/test/on_yubikey/test_cli_otp.py
+++ b/test/on_yubikey/test_cli_otp.py
@@ -378,17 +378,13 @@ class TestSlotProgramming(DestructiveYubikeyTestCase):
 
     def _check_slot_2_has_access_code(self):
         with self.assertRaises(SystemExit):
-            ykman_cli('otp', 'settings', '--new-access-code', '111111111111',
-                      '2', '-f')
+            ykman_cli('otp', 'settings', '--pacing', '0', '2', '-f')
 
         ykman_cli('otp', '--access-code', '111111111111', 'settings',
-                  '--new-access-code', '111111111111', '2', '-f')
+                  '--pacing', '0', '2', '-f')
 
     def _check_slot_2_does_not_have_access_code(self):
-        ykman_cli('otp', 'settings', '--new-access-code', '111111111111', '2',
-                  '-f')
-        ykman_cli('otp', '--access-code', '111111111111', 'settings',
-                  '--delete-access-code', '2', '-f')
+        ykman_cli('otp', 'settings', '--pacing', '0', '2', '-f')
 
 
 @unittest.skipIf(*missing_mode(TRANSPORT.OTP))

--- a/test/on_yubikey/test_cli_otp.py
+++ b/test/on_yubikey/test_cli_otp.py
@@ -271,7 +271,7 @@ class TestSlotProgramming(DestructiveYubikeyTestCase):
 
     @unittest.skipIf(get_version() not in [(4, 3, 4), (4, 3, 5)],
                      'Applicable only to YubiKey 4.3.4 and 4.3.5')
-    def test_set_access_code_fails_on_yk_434_and_435(self):
+    def test_update_access_code_fails_on_yk_434_and_435(self):
         ykman_cli('otp', 'static', '2', '--generate', '--length', '10')
 
         self._check_slot_2_programmed()
@@ -310,8 +310,8 @@ class TestSlotProgramming(DestructiveYubikeyTestCase):
         ykman_cli('otp', '--access-code', '111111111111', 'delete', '2', '-f')
 
     @unittest.skipIf(get_version() in [(4, 3, 4), (4, 3, 5)],
-                     'Set access code does not work on YubiKey 4.3.4 and 4.3.5')
-    def test_set_access_code_slot_2(self):
+                     'Update access code fails on YubiKey 4.3.4 and 4.3.5')
+    def test_update_access_code_slot_2(self):
         ykman_cli('otp', 'static', '2', '--generate', '--length', '10')
 
         self._check_slot_2_programmed()
@@ -328,8 +328,8 @@ class TestSlotProgramming(DestructiveYubikeyTestCase):
         ykman_cli('otp', 'delete', '2', '-f')
 
     @unittest.skipIf(get_version() in [(4, 3, 4), (4, 3, 5)],
-                     'Set access code does not work on YubiKey 4.3.4 and 4.3.5')
-    def test_set_access_code_prompt_slot_2(self):
+                     'Update access code fails on YubiKey 4.3.4 and 4.3.5')
+    def test_update_access_code_prompt_slot_2(self):
         ykman_cli('otp', 'static', '2', '--generate', '--length', '10')
 
         self._check_slot_2_programmed()
@@ -346,7 +346,7 @@ class TestSlotProgramming(DestructiveYubikeyTestCase):
         ykman_cli('otp', 'delete', '2', '-f')
 
     @unittest.skipIf(get_version() in [(4, 3, 4), (4, 3, 5)],
-                     'Set access code does not work on YubiKey 4.3.4 and 4.3.5')
+                     'Update access code fails on YubiKey 4.3.4 and 4.3.5')
     def test_new_access_code_conflicts_with_delete_access_code(self):
         ykman_cli('otp', 'static', '2', '--generate', '--length', '10')
 

--- a/test/on_yubikey/test_cli_otp.py
+++ b/test/on_yubikey/test_cli_otp.py
@@ -269,9 +269,9 @@ class TestSlotProgramming(DestructiveYubikeyTestCase):
         status = ykman_cli('otp', 'info')
         self.assertIn('Slot 2: empty', status)
 
-    @unittest.skipIf(get_version() not in [(4, 3, 4), (4, 3, 5)],
+    @unittest.skipIf(not (4, 3, 1) < get_version() < (4, 3, 6),
                      'Applicable only to YubiKey 4.3.4 and 4.3.5')
-    def test_update_access_code_fails_on_yk_434_and_435(self):
+    def test_update_access_code_fails_on_yk_432_to_435(self):
         ykman_cli('otp', 'static', '2', '--generate', '--length', '10')
 
         self._check_slot_2_programmed()
@@ -292,9 +292,9 @@ class TestSlotProgramming(DestructiveYubikeyTestCase):
 
         ykman_cli('otp', '--access-code', '111111111111', 'delete', '2', '-f')
 
-    @unittest.skipIf(get_version() not in [(4, 3, 4), (4, 3, 5)],
-                     'Applicable only to YubiKey 4.3.4 and 4.3.5')
-    def test_delete_access_code_fails_on_yk_434_and_435(self):
+    @unittest.skipIf(not (4, 3, 1) < get_version() < (4, 3, 6),
+                     'Applicable only to YubiKey 4.3.2 to 4.3.5')
+    def test_delete_access_code_fails_on_yk_432_to_435(self):
         ykman_cli('otp', '--access-code', '111111111111', 'static', '2',
                   '--generate', '--length', '10')
 
@@ -309,8 +309,8 @@ class TestSlotProgramming(DestructiveYubikeyTestCase):
 
         ykman_cli('otp', '--access-code', '111111111111', 'delete', '2', '-f')
 
-    @unittest.skipIf(get_version() in [(4, 3, 4), (4, 3, 5)],
-                     'Update access code fails on YubiKey 4.3.4 and 4.3.5')
+    @unittest.skipIf((4, 3, 1) < get_version() < (4, 3, 6),
+                     'Update access code fails on YubiKey 4.3.2 to 4.3.5')
     def test_update_access_code_slot_2(self):
         ykman_cli('otp', 'static', '2', '--generate', '--length', '10')
 
@@ -327,8 +327,8 @@ class TestSlotProgramming(DestructiveYubikeyTestCase):
 
         ykman_cli('otp', 'delete', '2', '-f')
 
-    @unittest.skipIf(get_version() in [(4, 3, 4), (4, 3, 5)],
-                     'Update access code fails on YubiKey 4.3.4 and 4.3.5')
+    @unittest.skipIf((4, 3, 1) < get_version() < (4, 3, 6),
+                     'Update access code fails on YubiKey 4.3.2 to 4.3.5')
     def test_update_access_code_prompt_slot_2(self):
         ykman_cli('otp', 'static', '2', '--generate', '--length', '10')
 
@@ -345,8 +345,8 @@ class TestSlotProgramming(DestructiveYubikeyTestCase):
 
         ykman_cli('otp', 'delete', '2', '-f')
 
-    @unittest.skipIf(get_version() in [(4, 3, 4), (4, 3, 5)],
-                     'Update access code fails on YubiKey 4.3.4 and 4.3.5')
+    @unittest.skipIf((4, 3, 1) < get_version() < (4, 3, 6),
+                     'Update access code fails on YubiKey 4.3.2 to 4.3.5')
     def test_new_access_code_conflicts_with_delete_access_code(self):
         ykman_cli('otp', 'static', '2', '--generate', '--length', '10')
 

--- a/test/on_yubikey/test_cli_otp.py
+++ b/test/on_yubikey/test_cli_otp.py
@@ -29,7 +29,8 @@
 
 import unittest
 from ykman.util import TRANSPORT
-from .util import (DestructiveYubikeyTestCase, missing_mode, ykman_cli)
+from .util import (DestructiveYubikeyTestCase, get_version, missing_mode,
+                   ykman_cli)
 
 
 @unittest.skipIf(*missing_mode(TRANSPORT.OTP))
@@ -268,6 +269,48 @@ class TestSlotProgramming(DestructiveYubikeyTestCase):
         status = ykman_cli('otp', 'info')
         self.assertIn('Slot 2: empty', status)
 
+    @unittest.skipIf(get_version() not in [(4, 3, 4), (4, 3, 5)],
+                     'Applicable only to YubiKey 4.3.4 and 4.3.5')
+    def test_set_access_code_fails_on_yk_434_and_435(self):
+        ykman_cli('otp', 'static', '2', '--generate', '--length', '10')
+
+        self._check_slot_2_programmed()
+
+        with self.assertRaises(SystemExit):
+            ykman_cli('otp', 'settings', '--new-access-code', '111111111111',
+                      '2', '-f')
+
+        ykman_cli('otp', '--access-code', '111111111111', 'static', '2', '-f',
+                  '--generate', '--length', '10')
+
+        with self.assertRaises(SystemExit):
+            ykman_cli('otp', 'delete', '2', '-f')
+
+        with self.assertRaises(SystemExit):
+            ykman_cli('otp', '--access-code', '111111111111', 'settings',
+                      '--new-access-code', '222222222222', '2', '-f')
+
+        ykman_cli('otp', '--access-code', '111111111111', 'delete', '2', '-f')
+
+    @unittest.skipIf(get_version() not in [(4, 3, 4), (4, 3, 5)],
+                     'Applicable only to YubiKey 4.3.4 and 4.3.5')
+    def test_delete_access_code_fails_on_yk_434_and_435(self):
+        ykman_cli('otp', '--access-code', '111111111111', 'static', '2',
+                  '--generate', '--length', '10')
+
+        self._check_slot_2_programmed()
+
+        with self.assertRaises(SystemExit):
+            ykman_cli('otp', '--access-code', '111111111111', 'settings',
+                      '--delete-access-code', '2', '-f')
+
+        with self.assertRaises(SystemExit):
+            ykman_cli('otp', 'delete', '2', '-f')
+
+        ykman_cli('otp', '--access-code', '111111111111', 'delete', '2', '-f')
+
+    @unittest.skipIf(get_version() in [(4, 3, 4), (4, 3, 5)],
+                     'Set access code does not work on YubiKey 4.3.4 and 4.3.5')
     def test_set_access_code_slot_2(self):
         ykman_cli('otp', 'static', '2', '--generate', '--length', '10')
 
@@ -284,6 +327,8 @@ class TestSlotProgramming(DestructiveYubikeyTestCase):
 
         ykman_cli('otp', 'delete', '2', '-f')
 
+    @unittest.skipIf(get_version() in [(4, 3, 4), (4, 3, 5)],
+                     'Set access code does not work on YubiKey 4.3.4 and 4.3.5')
     def test_set_access_code_prompt_slot_2(self):
         ykman_cli('otp', 'static', '2', '--generate', '--length', '10')
 
@@ -300,6 +345,8 @@ class TestSlotProgramming(DestructiveYubikeyTestCase):
 
         ykman_cli('otp', 'delete', '2', '-f')
 
+    @unittest.skipIf(get_version() in [(4, 3, 4), (4, 3, 5)],
+                     'Set access code does not work on YubiKey 4.3.4 and 4.3.5')
     def test_new_access_code_conflicts_with_delete_access_code(self):
         ykman_cli('otp', 'static', '2', '--generate', '--length', '10')
 

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -548,10 +548,18 @@ def settings(ctx, slot, new_access_code, delete_access_code, enter, pacing,
         _failed_to_write_msg(ctx, e)
 
     if new_access_code:
-        controller.set_access_code(slot, new_access_code)
+        try:
+            controller.set_access_code(slot, new_access_code)
+        except Exception as e:
+            logger.error('Failed to set access code', exc_info=e)
+            ctx.fail('Failed to set access code: ' + str(e))
 
     if delete_access_code:
-        controller.delete_access_code(slot)
+        try:
+            controller.delete_access_code(slot)
+        except Exception as e:
+            logger.error('Failed to delete access code', exc_info=e)
+            ctx.fail('Failed to delete access code: ' + str(e))
 
 
 otp.transports = TRANSPORT.OTP

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -327,13 +327,13 @@ class OtpController(object):
 
     @property
     def _has_set_access_code_bug(self):
-        v = self._driver.version
-        if v <= (4, 3, 1) or v >= (4, 3, 6):
-            return _HasSetAccessCodeBug(True, False)
-        elif v >= (4, 3, 4) and v < (4, 3, 6):
-            return _HasSetAccessCodeBug(True, True)
+        if (4, 3, 1) < self._driver.version < (4, 3, 6):
+            if (4, 3, 4) <= self._driver.version <= (4, 3, 5):
+                return _HasSetAccessCodeBug(True, True)
+            else:
+                return _HasSetAccessCodeBug(False, None)
         else:
-            return _HasSetAccessCodeBug(False, None)
+            return _HasSetAccessCodeBug(True, False)
 
     def _verify_set_access_code_supported(self, slot, new_code):
         if self._has_set_access_code_bug.certain:

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -273,7 +273,7 @@ class OtpController(object):
             ykpers.ykp_free_ndef(ndef)
 
     @property
-    def _has_set_access_code_bug(self):
+    def _has_update_access_code_bug(self):
         return (4, 3, 1) < self._driver.version < (4, 3, 6)
 
     def set_access_code(self, slot, new_code=None, update=True,
@@ -284,9 +284,9 @@ class OtpController(object):
             raise ValueError('Cannot set new access code unless updating slot')
         if new_code == _RESET_ACCESS_CODE:
             raise ValueError('Cannot set access code to special value zero.')
-        if new_code is not None and self._has_set_access_code_bug:
+        if new_code is not None and self._has_update_access_code_bug:
             raise ValueError(
-                'This YubiKey firmware does not support setting the access '
+                'This YubiKey firmware does not support updating the access '
                 'code after programming the slot. Please set the access '
                 'code when initially programming the slot instead.')
 
@@ -305,7 +305,7 @@ class OtpController(object):
             ykpers.ykp_free_config(cfg)
 
     def delete_access_code(self, slot):
-        if self._has_set_access_code_bug:
+        if self._has_update_access_code_bug:
             raise ValueError(
                 'This YubiKey firmware does not support deleting the access '
                 'code after programming the slot. Please delete and re-program '

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -50,6 +50,7 @@ class SLOT(IntEnum):
 
 SLOTS = [-1, 0x30, 0x38]
 _RESET_ACCESS_CODE = b'\x00' * 6
+_ACCESS_CODE_LENGTH = 6
 
 
 def slot_to_cmd(slot, update=False):
@@ -87,7 +88,7 @@ class OtpController(object):
             check(ykpers.ykp_set_extflag(cfg, 'ALLOW_UPDATE'))
             if self.access_code is not None:
                 check(ykpers.ykp_set_access_code(
-                    cfg, self.access_code, len(self.access_code)))
+                    cfg, self.access_code, _ACCESS_CODE_LENGTH))
             return cfg
         except YkpersError:
             ykpers.ykp_free_config(cfg)
@@ -294,7 +295,8 @@ class OtpController(object):
         try:
             if new_code is None:
                 new_code = _RESET_ACCESS_CODE
-            check(ykpers.ykp_set_access_code(cfg, new_code, len(new_code)))
+            check(ykpers.ykp_set_access_code(
+                cfg, new_code, _ACCESS_CODE_LENGTH))
             ycfg = ykpers.ykp_core_config(cfg)
             check(ykpers.yk_write_command(self._dev, ycfg, cmd,
                                           self.access_code))

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -49,7 +49,7 @@ class SLOT(IntEnum):
 
 
 SLOTS = [-1, 0x30, 0x38]
-RESET_ACCESS_CODE = b'\x00' * 6
+_RESET_ACCESS_CODE = b'\x00' * 6
 
 
 def slot_to_cmd(slot, update=False):
@@ -276,14 +276,14 @@ class OtpController(object):
             raise ValueError('Update requires YubiKey 2.3.0 or later')
         if not update and new_code is not None:
             raise ValueError('Cannot set new access code unless updating slot')
-        if new_code == RESET_ACCESS_CODE:
+        if new_code == _RESET_ACCESS_CODE:
             raise ValueError('Cannot set access code to special value zero.')
 
         cmd = slot_to_cmd(slot, update)
         cfg = self._create_cfg(cmd)
         try:
             if new_code is None:
-                new_code = RESET_ACCESS_CODE
+                new_code = _RESET_ACCESS_CODE
             check(ykpers.ykp_set_access_code(cfg, new_code, len(new_code)))
             ycfg = ykpers.ykp_core_config(cfg)
             check(ykpers.yk_write_command(self._dev, ycfg, cmd,

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -293,18 +293,13 @@ class OtpController(object):
         cmd = slot_to_cmd(slot, update)
         cfg = self._create_cfg(cmd)
         try:
-            if new_code is None:
-                new_code = _RESET_ACCESS_CODE
             check(ykpers.ykp_set_access_code(
-                cfg, new_code, _ACCESS_CODE_LENGTH))
+                cfg, new_code or _RESET_ACCESS_CODE, _ACCESS_CODE_LENGTH))
             ycfg = ykpers.ykp_core_config(cfg)
             check(ykpers.yk_write_command(self._dev, ycfg, cmd,
                                           self.access_code))
 
-            if new_code == _RESET_ACCESS_CODE:
-                self.access_code = None
-            else:
-                self.access_code = new_code
+            self.access_code = new_code
 
         finally:
             ykpers.ykp_free_config(cfg)

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -331,7 +331,7 @@ class OtpController(object):
             if (4, 3, 4) <= self._driver.version <= (4, 3, 5):
                 return _HasSetAccessCodeBug(True, True)
             else:
-                return _HasSetAccessCodeBug(False, None)
+                return _HasSetAccessCodeBug(False, True)
         else:
             return _HasSetAccessCodeBug(True, False)
 

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -49,8 +49,8 @@ class SLOT(IntEnum):
 
 
 SLOTS = [-1, 0x30, 0x38]
-_RESET_ACCESS_CODE = b'\x00' * 6
 _ACCESS_CODE_LENGTH = 6
+_RESET_ACCESS_CODE = b'\x00' * _ACCESS_CODE_LENGTH
 
 
 def slot_to_cmd(slot, update=False):

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -327,8 +327,6 @@ class OtpController(object):
 
     @property
     def _has_set_access_code_bug(self):
-        return _HasSetAccessCodeBug(False, None)
-
         v = self._driver.version
         if v <= (4, 3, 1) or v >= (4, 3, 6):
             return _HasSetAccessCodeBug(True, False)


### PR DESCRIPTION
Some YubiKey firmware versions silently fail to change the access code, as @dagheyman [discovered][report] in #122. ~~With these changes , ykman will make a couple of extra calls to the YubiKey to verify that the access code was in fact set or deleted as expected. If not, an error is raised. See the inline docstring and comments for details on how these deductions are made.~~ With these changes, ykman will refuse to perform these operations on affected firmware versions.

[report]: https://github.com/Yubico/yubikey-manager/pull/122#issuecomment-399855281