### PR TITLE
fido: block reset when multiple keys are connected

### DIFF
--- a/ykman/cli/fido.py
+++ b/ykman/cli/fido.py
@@ -200,6 +200,10 @@ def reset(ctx, force):
     inserted, and requires a touch on the YubiKey.
     """
 
+    n_keys = len(list(get_descriptors()))
+    if n_keys > 1:
+        ctx.fail('Only one YubiKey can be connected to perform a reset.')
+
     if not force:
         if not click.confirm('WARNING! This will delete all FIDO credentials, '
                              'including FIDO U2F credentials, and restore '


### PR DESCRIPTION
We did not handle `fido reset` with multiple keys connected well, it required all keys to be removed. Supporting doing reset on a specific YubiKey might be possible, but requires bigger changes. Let's start with explicitly blocking this and giving a proper error message when multiple keys are connected.