### PR TITLE
Add class methods for inspecting verify fail (0x63cX) status words

### DIFF
--- a/ykman/piv.py
+++ b/ykman/piv.py
@@ -256,12 +256,12 @@ class SW(IntEnum):
     AUTHENTICATION_BLOCKED = 0x6983
     INCORRECT_PARAMETERS = 0x6a80
 
-    @classmethod
-    def is_verify_fail(cls, sw):
+    @staticmethod
+    def is_verify_fail(sw):
         return 0x63c0 <= sw <= 0x63c3
 
-    @classmethod
-    def tries_left(cls, sw):
+    @staticmethod
+    def tries_left(sw):
         # Blocked, 0 tries left.
         if sw == SW.AUTHENTICATION_BLOCKED:
             return 0

--- a/ykman/piv.py
+++ b/ykman/piv.py
@@ -256,6 +256,16 @@ class SW(IntEnum):
     AUTHENTICATION_BLOCKED = 0x6983
     INCORRECT_PARAMETERS = 0x6a80
 
+    @classmethod
+    def is_verify_fail(cls, sw):
+        return 0x63c0 <= sw <= 0x63c3
+
+    @classmethod
+    def tries_left(cls, sw):
+        if not cls.is_verify_fail(sw):
+            raise ValueError('Not a verify fail status word: %x' % sw)
+        return sw - 0x63c0
+
 
 CodeChangeResult = namedtuple('CodeChangeResult', ['success', 'tries_left'])
 

--- a/ykman/piv.py
+++ b/ykman/piv.py
@@ -263,11 +263,15 @@ class SW(IntEnum):
         else:
             return 0x63c0 <= sw <= 0x63cf
 
-    @staticmethod
-    def tries_left(sw, applet_version):
+    @classmethod
+    def tries_left(cls, sw, applet_version):
         # Blocked, 0 tries left.
         if sw == SW.AUTHENTICATION_BLOCKED:
             return 0
+
+        if not cls.is_verify_fail(sw, applet_version):
+            raise ValueError(
+                'Cannot read remaining tries from status word: %x' % sw)
 
         if applet_version < (1, 0, 4):
             return sw & 0xff

--- a/ykman/piv.py
+++ b/ykman/piv.py
@@ -258,7 +258,7 @@ class SW(IntEnum):
 
     @staticmethod
     def is_verify_fail(sw):
-        return 0x63c0 <= sw <= 0x63c3
+        return 0x63c0 <= sw <= 0x63cf
 
     @staticmethod
     def tries_left(sw):


### PR DESCRIPTION
An alternative approach would be to add similar methods to APDUError instead.