### PR TITLE
static pw: add support for ` in us keyboard layout

### DIFF
--- a/test/test_scancodes.py
+++ b/test/test_scancodes.py
@@ -115,6 +115,7 @@ class TestScanMap(unittest.TestCase):
         self.assertEqual(b'\xa7', encode(')', KEYBOARD_LAYOUT.US))
         self.assertEqual(b'\xa5', encode('*', KEYBOARD_LAYOUT.US))
         self.assertEqual(b'\xae', encode('+', KEYBOARD_LAYOUT.US))
+        self.assertEqual(b'\x35', encode('`', KEYBOARD_LAYOUT.US))
         self.assertEqual(b'\x36', encode(',', KEYBOARD_LAYOUT.US))
         self.assertEqual(b'\x2d', encode('-', KEYBOARD_LAYOUT.US))
         self.assertEqual(b'\x37', encode('.', KEYBOARD_LAYOUT.US))

--- a/ykman/scancodes/us.py
+++ b/ykman/scancodes/us.py
@@ -103,6 +103,7 @@ scancodes = {
     '%': 0x22 | SHIFT,
     '&': 0x24 | SHIFT,
     "'": 0x34,
+    "`" : 0x35,
     '(': 0x26 | SHIFT,
     ')': 0x27 | SHIFT,
     '*': 0x25 | SHIFT,


### PR DESCRIPTION
"`" should be supported when using the US keyboard layout. See:
https://github.com/Yubico/yubikey-personalization-gui/blob/master/lib/us-scanedit.cpp#L131