### PR TITLE
help: don't evaluate all help commands at once

### DIFF
--- a/ykman/cli/util.py
+++ b/ykman/cli/util.py
@@ -72,7 +72,7 @@ def click_skip_on_help(f):
     def inner(*args, **kwargs):
         ctx = click.get_current_context()
         for arg in ctx.help_option_names:
-            if arg in sys.argv:
+            if arg in ctx.args:
                 return
         f(*args, **kwargs)
     return inner


### PR DESCRIPTION
~~Use ctx.args instead of sys.argv, which will give~~
~~the arguments for the current command. Fixes crash~~
~~caused by using the help flag like a value like this:~~

~~$ ykman config set-lock-code -n -h~~

Edit: this wont work because it will fail to early for example if a transport is disabled.