### PR TITLE
WIP: cli: add callback to block help flags as input

### DIFF
--- a/ykman/cli/config.py
+++ b/ykman/cli/config.py
@@ -27,7 +27,9 @@
 
 from __future__ import absolute_import
 
-from .util import click_skip_on_help, click_force_option, UpperCaseChoice
+from .util import (
+    click_skip_on_help, click_force_option, click_cleanup_help, UpperCaseChoice
+    )
 from ..device import device_config, FLAGS
 from ..util import APPLICATION
 from binascii import a2b_hex, b2a_hex
@@ -69,7 +71,7 @@ def config(ctx):
 @click.option('-l', '--lock-code', metavar='HEX', help='Current lock code.')
 @click.option(
     '-n', '--new-lock-code', metavar='HEX',
-    help='New lock code. Conflicts with --generate.')
+    help='New lock code. Conflicts with --generate.', callback=click_cleanup_help)
 @click.option('-c', '--clear', is_flag=True, help='Clear the lock code.')
 @click.option(
     '-g', '--generate', is_flag=True,

--- a/ykman/cli/oath.py
+++ b/ykman/cli/oath.py
@@ -32,6 +32,7 @@ from threading import Timer
 from binascii import b2a_hex, a2b_hex
 from .util import (
     click_force_option, click_skip_on_help,
+    click_cleanup_help,
     click_callback, click_parse_b32_key,
     prompt_for_touch, UpperCaseChoice)
 from ..driver_ccid import (
@@ -165,7 +166,7 @@ def reset(ctx):
 @click.option(
     '-c', '--counter', type=click.INT, default=0,
     help='Initial counter value for HOTP credentials.')
-@click.option('-i', '--issuer', help='Issuer of the credential.')
+@click.option('-i', '--issuer', help='Issuer of the credential.', callback=click_cleanup_help)
 @click.option(
     '-p', '--period', help='Number of seconds a TOTP code is valid.',
     default=30, show_default=True)

--- a/ykman/cli/util.py
+++ b/ykman/cli/util.py
@@ -83,6 +83,17 @@ def click_parse_b32_key(ctx, param, val):
     return parse_b32_key(val)
 
 
+def click_cleanup_help(ctx, param, val):
+    """
+    Add this as a callback for options on
+    leafs that take a text argument, to not
+    accept help flags as input data.
+    """
+    if val in ctx.help_option_names:
+        click.echo(ctx.get_help())
+        ctx.exit()
+
+
 def prompt_for_touch():
     try:
         click.echo('Touch your YubiKey...', err=True)


### PR DESCRIPTION
useful for options on leaf sub-commands that accepts text as input.

tries to solve the same problem as #164 