### PR TITLE
prompt on stderr on all prompts

### DIFF
--- a/ykman/cli/config.py
+++ b/ykman/cli/config.py
@@ -43,7 +43,7 @@ CLEAR_LOCK_CODE = '0' * 32
 
 
 def prompt_lock_code(prompt='Enter your lock code'):
-    return click.prompt(prompt, default='', hide_input=True, show_default=False)
+    return click.prompt(prompt, default='', hide_input=True, show_default=False, err=True)
 
 
 @click.group()

--- a/ykman/cli/fido.py
+++ b/ykman/cli/fido.py
@@ -124,7 +124,7 @@ def set_pin(ctx, pin, new_pin, u2f):
     def prompt_new_pin():
         return click.prompt(
                     'Enter your new PIN', default='', hide_input=True,
-                    show_default=False, confirmation_prompt=True)
+                    show_default=False, confirmation_prompt=True, err=True)
 
     def change_pin(pin, new_pin):
         if pin is not None:
@@ -242,7 +242,8 @@ def reset(ctx, force):
                 'device.\n'
                 'To proceed, please enter the text "OVERWRITE"',
                 default='',
-                show_default=False
+                show_default=False,
+                err=True
             )
             if destroy_input != 'OVERWRITE':
                 ctx.fail('Reset aborted by user.')
@@ -317,7 +318,7 @@ def unlock(ctx, pin):
 
 
 def _prompt_current_pin(prompt='Enter your current PIN'):
-    return click.prompt(prompt, default='', hide_input=True, show_default=False)
+    return click.prompt(prompt, default='', hide_input=True, show_default=False, err=True)
 
 
 def _fail_if_not_valid_pin(ctx, pin=None, is_fips=False):

--- a/ykman/cli/oath.py
+++ b/ykman/cli/oath.py
@@ -189,7 +189,7 @@ def add(ctx, secret, name, issuer, period, oath_type, digits, touch, algorithm,
 
     if not secret:
         while True:
-            secret = click.prompt('Enter a secret key (base32)')
+            secret = click.prompt('Enter a secret key (base32)', err=True)
             try:
                 secret = parse_b32_key(secret)
                 break
@@ -217,7 +217,7 @@ def uri(ctx, uri, touch, force):
 
     if not uri:
         while True:
-            uri = click.prompt('Enter an OATH URI')
+            uri = click.prompt('Enter an OATH URI', err=True)
             try:
                 uri = CredentialData.from_uri(uri)
                 break
@@ -438,7 +438,8 @@ def set_password(ctx, new_password, remember):
         new_password = click.prompt(
             'Enter your new password',
             hide_input=True,
-            confirmation_prompt=True)
+            confirmation_prompt=True,
+            err=True)
 
     controller = ctx.obj['controller']
     settings = ctx.obj['settings']
@@ -500,7 +501,7 @@ def ensure_validated(ctx, prompt='Enter your password', remember=False):
                 del keys[controller.id]
 
         # Prompt for password
-        password = click.prompt(prompt, hide_input=True)
+        password = click.prompt(prompt, hide_input=True, err=True)
         key = controller.derive_key(password)
         _validate(ctx, key, remember)
 

--- a/ykman/cli/opgp.py
+++ b/ykman/cli/opgp.py
@@ -162,7 +162,7 @@ def touch(ctx, key, policy, admin_pin, force):
     force or click.confirm('Set touch policy of {.name} key to {.name}?'.format(
         key, policy), abort=True)
     if admin_pin is None:
-        admin_pin = click.prompt('Enter admin PIN', hide_input=True)
+        admin_pin = click.prompt('Enter admin PIN', hide_input=True, err=True)
     controller.set_touch(key, policy, admin_pin.encode('utf8'))
     click.echo('Touch policy successfully set.')
 

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -111,7 +111,7 @@ def otp(ctx, access_code):
     ctx.obj['controller'] = OtpController(ctx.obj['dev'].driver)
     if access_code is not None:
         if access_code == '':
-            access_code = click.prompt('Enter access code', show_default=False)
+            access_code = click.prompt('Enter access code', show_default=False, err=True)
 
         try:
             access_code = parse_access_code_hex(access_code)
@@ -260,7 +260,7 @@ def yubiotp(ctx, slot, public_id, private_id, key, no_enter, force,
                 'Public ID not given. Please remove the --force flag, or '
                 'add the --serial-public-id flag or --public-id option.')
         else:
-            public_id = click.prompt('Enter public ID')
+            public_id = click.prompt('Enter public ID', err=True)
 
     try:
         public_id = modhex_decode(public_id)
@@ -278,7 +278,7 @@ def yubiotp(ctx, slot, public_id, private_id, key, no_enter, force,
                 'Private ID not given. Please remove the --force flag, or '
                 'add the --generate-private-id flag or --private-id option.')
         else:
-            private_id = click.prompt('Enter private ID')
+            private_id = click.prompt('Enter private ID', err=True)
             private_id = a2b_hex(private_id)
 
     if not key:
@@ -291,7 +291,7 @@ def yubiotp(ctx, slot, public_id, private_id, key, no_enter, force,
             ctx.fail('Secret key not given. Please remove the --force flag, or '
                      'add the --generate-key flag or --key option.')
         else:
-            key = click.prompt('Enter secret key')
+            key = click.prompt('Enter secret key', err=True)
             key = a2b_hex(key)
 
     force or click.confirm('Program an OTP credential in slot {}?'.format(slot),
@@ -341,7 +341,7 @@ def static(
         ctx.fail('Provide a length for the generated password.')
 
     if not password and not generate:
-        password = click.prompt('Enter a static password')
+        password = click.prompt('Enter a static password', err=True)
     elif not password and generate:
         password = generate_static_pw(length, keyboard_layout).decode()
 
@@ -389,7 +389,7 @@ def chalresp(ctx, slot, key, totp, touch, force, generate):
                      'set the KEY argument or set the --generate flag.')
         elif totp:
             while True:
-                key = click.prompt('Enter a secret key (base32)')
+                key = click.prompt('Enter a secret key (base32)', err=True)
                 try:
                     key = parse_b32_key(key)
                     break
@@ -402,7 +402,7 @@ def chalresp(ctx, slot, key, totp, touch, force, generate):
                 click.echo('Using a randomly generated key: {}'.format(
                     b2a_hex(key).decode('ascii')))
             else:
-                key = click.prompt('Enter a secret key')
+                key = click.prompt('Enter a secret key', err=True)
                 key = parse_key(key)
 
     cred_type = 'TOTP' if totp else 'challenge-response'
@@ -489,7 +489,7 @@ def hotp(ctx, slot, key, digits, counter, no_enter, force):
     controller = ctx.obj['controller']
     if not key:
         while True:
-            key = click.prompt('Enter a secret key (base32)')
+            key = click.prompt('Enter a secret key (base32)', err=True)
             try:
                 key = parse_b32_key(key)
                 break
@@ -543,7 +543,7 @@ def settings(ctx, slot, new_access_code, delete_access_code, enter, pacing,
     if new_access_code is not None:
         if new_access_code == '':
             new_access_code = click.prompt(
-                'Enter new access code', show_default=False)
+                'Enter new access code', show_default=False, err=True)
 
         try:
             new_access_code = parse_access_code_hex(new_access_code)

--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -278,7 +278,8 @@ def import_certificate(
                 password = click.prompt(
                     'Enter password to decrypt certificate',
                     default='', hide_input=True,
-                    show_default=False)
+                    show_default=False,
+                    err=True)
                 continue
             else:
                 password = None
@@ -327,7 +328,8 @@ def import_key(
                 password = click.prompt(
                     'Enter password to decrypt key',
                     default='', hide_input=True,
-                    show_default=False)
+                    show_default=False,
+                    err=True)
                 continue
             else:
                 password = None
@@ -583,7 +585,7 @@ def change_pin(ctx, pin, new_pin):
     if not new_pin:
         new_pin = click.prompt(
             'Enter your new PIN', default='', hide_input=True,
-            show_default=False, confirmation_prompt=True)
+            show_default=False, confirmation_prompt=True, err=True)
     try:
         controller.change_pin(pin, new_pin)
     except APDUError as e:
@@ -608,7 +610,8 @@ def change_puk(ctx, puk, new_puk):
     if not new_puk:
         new_puk = click.prompt(
             'Enter your new PUK', default='', hide_input=True,
-            show_default=False, confirmation_prompt=True)
+            show_default=False, confirmation_prompt=True,
+            err=True)
 
     (success, retries) = controller.change_puk(puk, new_puk)
 
@@ -723,17 +726,19 @@ def unblock_pin(ctx, puk, new_pin):
     controller = ctx.obj['controller']
     if not puk:
         puk = click.prompt(
-            'Enter PUK', default='', show_default=False, hide_input=True)
+            'Enter PUK', default='', show_default=False,
+            hide_input=True, err=True)
     if not new_pin:
         new_pin = click.prompt(
-            'Enter a new PIN', default='', show_default=False, hide_input=True)
+            'Enter a new PIN', default='',
+            show_default=False, hide_input=True, err=True)
     controller.unblock_pin(puk, new_pin)
 
 
 def _prompt_management_key(
         ctx, prompt='Enter a management key [blank to use default key]'):
     management_key = click.prompt(
-        prompt, default='', hide_input=True, show_default=False)
+        prompt, default='', hide_input=True, show_default=False, err=True)
     if management_key == '':
         return DEFAULT_MANAGEMENT_KEY
     try:
@@ -744,7 +749,7 @@ def _prompt_management_key(
 
 def _prompt_pin(ctx, prompt='Enter PIN'):
     return click.prompt(
-        prompt, default='', hide_input=True, show_default=False)
+        prompt, default='', hide_input=True, show_default=False, err=True)
 
 
 def _ensure_authenticated(


### PR DESCRIPTION
By showing all interactive prompts on stderr instead, we make commands like this possible: 
`$ ykman piv generate-key 9a - > out.txt` (which would otherwise redirect the prompt to `out.txt`.) Follows [POSIX standard](https://unix.stackexchange.com/a/381081) better as well.