### PR TITLE
Add support for external reader flag

### DIFF
--- a/ykman/cli/__main__.py
+++ b/ykman/cli/__main__.py
@@ -147,7 +147,7 @@ def _run_cmd_for_single(ctx, cmd, transports, reader=None):
               )
 @click.option(
         '-r', '--reader',
-        help='Use an external smart card reader.',
+        help='Use an external smart card reader. Conflicts with --device and list.',
         metavar='NAME', default=None)
 @click.pass_context
 def cli(ctx, device, log_level, log_file, reader):
@@ -159,8 +159,13 @@ def cli(ctx, device, log_level, log_file, reader):
     if log_level:
         ykman.logging_setup.setup(log_level, log_file=log_file)
 
+    if reader and device:
+        ctx.fail('--reader and --device options can\'t be combined.')
+
     subcmd = next(c for c in COMMANDS if c.name == ctx.invoked_subcommand)
     if subcmd == list_keys:
+        if reader:
+            ctx.fail('--reader and list command can\'t be combined.')
         return
 
     transports = getattr(subcmd, 'transports', TRANSPORT.usb_transports())

--- a/ykman/device.py
+++ b/ykman/device.py
@@ -249,15 +249,16 @@ class YubiKey(object):
                 self._can_mode_switch = False
 
         # Fix usb_enabled
-        usb_enabled = config.usb_enabled or config.usb_supported
-        if not TRANSPORT.has(self.mode.transports, TRANSPORT.OTP):
-            usb_enabled &= ~APPLICATION.OTP
-        if not TRANSPORT.has(self.mode.transports, TRANSPORT.FIDO):
-            usb_enabled &= ~(APPLICATION.U2F | APPLICATION.FIDO2)
-        if not TRANSPORT.has(self.mode.transports, TRANSPORT.CCID):
-            usb_enabled &= ~(TRANSPORT.CCID | APPLICATION.OATH |
+        if not config.usb_enabled:
+            usb_enabled = config.usb_supported
+            if not TRANSPORT.has(self.mode.transports, TRANSPORT.OTP):
+                usb_enabled &= ~APPLICATION.OTP
+            if not TRANSPORT.has(self.mode.transports, TRANSPORT.FIDO):
+               usb_enabled &= ~(APPLICATION.U2F | APPLICATION.FIDO2)
+            if not TRANSPORT.has(self.mode.transports, TRANSPORT.CCID):
+                usb_enabled &= ~(TRANSPORT.CCID | APPLICATION.OATH |
                              APPLICATION.OPGP | APPLICATION.PIV)
-        config._set(TAG.USB_ENABLED, usb_enabled)
+            config._set(TAG.USB_ENABLED, usb_enabled)
 
         # Workaround for invalid configurations.
         # Assume all form factors except USB_A_KEYCHAIN


### PR DESCRIPTION
Add minimal support for external smart card readers with a `-r/--reader` flag to ykman. Works only for CCID commands and for a single YubiKey.

Example usage with a HID OmniKey Reader:
`$ ykman --reader HID oath code`