### PR TITLE
Spelling

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -88,7 +88,7 @@
 
 * Version 0.4.1 (released 2017-08-10)
  ** PIV: Dropped support for deriving a management key from PIN.
- ** PIV: Addded support for generating a random management key and storing it on the device protected by the PIN.
+ ** PIV: Added support for generating a random management key and storing it on the device protected by the PIN.
  ** OpenPGP: The reset command now handles a device in terminated state.
  ** OATH: Credential filtering is now working properly on Python 2.
 

--- a/NEWS
+++ b/NEWS
@@ -76,10 +76,10 @@
  ** OATH: Don't print issuer if there is no issuer.
 
 * Version 0.4.4 (released 2017-09-06)
- ** OATH: Fix yet another issue with backwards compability, for adding new credentials.
+ ** OATH: Fix yet another issue with backwards compatibility, for adding new credentials.
 
 * Version 0.4.3 (released 2017-09-06)
- ** OATH: Fix issue with backwards compability, when used as a library.
+ ** OATH: Fix issue with backwards compatibility, when used as a library.
 
 * Version 0.4.2 (released 2017-09-05)
  ** OATH: Support 7 digit credentials.

--- a/NEWS
+++ b/NEWS
@@ -45,7 +45,7 @@
  ** CLI breaking changes:
   *** OATH: Touch prompt now written to stderr instead of stdout
   *** OATH: `-a|--algorithm` option to `list` command removed
-  *** OATH: Columns in `code` command are now dymanically spaced depending on contents
+  *** OATH: Columns in `code` command are now dynamically spaced depending on contents
   *** OATH: `delete` command now requires confirmation or `-f|--force` argument
   *** OATH: IDs printed by `list` command now include TOTP period if not 30
   *** Changed outputs:

--- a/test/test_oath.py
+++ b/test/test_oath.py
@@ -12,10 +12,10 @@ class TestOathFunctions(unittest.TestCase):
         self.assertEqual('Issuer', issuer)
         self.assertEqual('name', name)
 
-    def test_credential_parse_wierd_issuer_and_name(self):
-        issuer, name, period = Credential.parse_key(b'wierd/Issuer:name')
+    def test_credential_parse_weird_issuer_and_name(self):
+        issuer, name, period = Credential.parse_key(b'weird/Issuer:name')
         self.assertEqual(30, period)
-        self.assertEqual('wierd/Issuer', issuer)
+        self.assertEqual('weird/Issuer', issuer)
         self.assertEqual('name', name)
 
     def test_credential_parse_issuer_and_name(self):

--- a/ykman/piv.py
+++ b/ykman/piv.py
@@ -507,7 +507,7 @@ class PivController(object):
                 self.get_data(OBJ.PIVMAN_PROTECTED_DATA))
         except APDUError as e:
             if e.sw == SW_APPLICATION_NOT_FOUND:
-                # No data there, initialise a new object.
+                # No data there, initialize a new object.
                 self._pivman_protected_data = PivmanProtectedData()
             else:
                 raise

--- a/ykman/util.py
+++ b/ykman/util.py
@@ -451,7 +451,7 @@ def parse_private_key(data, password):
 
 def parse_certificate(data, password):
     """
-    Identifies, decrypts and returns a cryptography x509 certficate.
+    Identifies, decrypts and returns a cryptography x509 certificate.
     """
     # PEM
     if data.startswith(b'-----'):


### PR DESCRIPTION
Generated by https://github.com/jsoref/spelling `f`; to maintain your repo, please consider `fchurn`