### PR TITLE
Extract method PivController.supported_algorithms

### DIFF
--- a/test/on_yubikey/util.py
+++ b/test/on_yubikey/util.py
@@ -94,6 +94,13 @@ def ykman_cli(*args, **kwargs):
     )
 
 
+def ykman_cli_raw(*args, **kwargs):
+    return test.util.ykman_cli_raw(
+        '--device', _test_serial,
+        *args, **kwargs
+    )
+
+
 def open_device(transports=sum(TRANSPORT)):
     return ykman.descriptor.open_device(transports=transports,
                                         serial=int(_test_serial))

--- a/test/test_piv.py
+++ b/test/test_piv.py
@@ -3,6 +3,17 @@
 import ykman.piv as piv
 import unittest
 
+from ykman.piv import ALGO
+
+
+class FakeController(object):
+    def __init__(self, version):
+        self.version = version
+
+    @property
+    def is_fips(self):
+        return piv.PivController.is_fips.fget(self)
+
 
 class TestPivFunctions(unittest.TestCase):
 
@@ -12,3 +23,27 @@ class TestPivFunctions(unittest.TestCase):
         self.assertIsInstance(output1, bytes)
         self.assertIsInstance(output2, bytes)
         self.assertNotEqual(output1, output2)
+
+    def test_supported_algorithms(self):
+        neo_supported = piv.PivController.supported_algorithms.fget(
+            FakeController((3, 1, 1)))
+        self.assertNotIn(ALGO.TDES, neo_supported)
+        self.assertNotIn(ALGO.ECCP384, neo_supported)
+
+        fips_supported = piv.PivController.supported_algorithms.fget(
+            FakeController((4, 4, 1)))
+        self.assertNotIn(ALGO.TDES, fips_supported)
+        self.assertNotIn(ALGO.RSA1024, fips_supported)
+
+        roca_supported = piv.PivController.supported_algorithms.fget(
+            FakeController((4, 3, 4)))
+        self.assertNotIn(ALGO.TDES, roca_supported)
+        self.assertNotIn(ALGO.RSA1024, roca_supported)
+        self.assertNotIn(ALGO.RSA2048, roca_supported)
+
+        yk5_supported = piv.PivController.supported_algorithms.fget(
+            FakeController((5, 1, 0)))
+        self.assertEqual(
+            set(yk5_supported),
+            set([a for a in ALGO if a != ALGO.TDES]),
+        )

--- a/test/util.py
+++ b/test/util.py
@@ -11,8 +11,13 @@ def open_file(*relative_path):
 
 
 def ykman_cli(*argv, **kwargs):
-    runner = CliRunner()
-    result = runner.invoke(cli, list(argv), obj={}, **kwargs)
+    result = ykman_cli_raw(*argv, **kwargs)
     if result.exit_code != 0:
         raise result.exception
     return result.output
+
+
+def ykman_cli_raw(*argv, **kwargs):
+    runner = CliRunner()
+    result = runner.invoke(cli, list(argv), obj={}, **kwargs)
+    return result

--- a/ykman/device.py
+++ b/ykman/device.py
@@ -343,7 +343,11 @@ class YubiKey(object):
 
     @property
     def is_fips(self):
-        return (4, 4, 0) <= self.version < (4, 5, 0)
+        return YubiKey.is_fips_version(self.version)
+
+    @staticmethod
+    def is_fips_version(version):
+        return (4, 4, 0) <= version < (4, 5, 0)
 
     @mode.setter
     def mode(self, mode):

--- a/ykman/piv.py
+++ b/ykman/piv.py
@@ -28,6 +28,7 @@
 
 from __future__ import absolute_import
 from enum import IntEnum, unique
+from .device import YubiKey
 from .driver_ccid import APDUError, SW
 from .util import (
     AID, Tlv, parse_tlvs,
@@ -1050,10 +1051,6 @@ class PivController(object):
             return [policy for policy in TOUCH_POLICY]
 
     @property
-    def is_fips(self):
-        return (4, 4, 0) <= self.version < (4, 5, 0)
-
-    @property
     def supported_algorithms(self):
         return [
             alg for alg in ALGO
@@ -1062,5 +1059,6 @@ class PivController(object):
             if not (ALGO.is_rsa(alg) and
                     is_cve201715361_vulnerable_firmware_version(self.version))
             if not (alg == ALGO.ECCP384 and self.version < (4, 0, 0))
-            if not (alg == ALGO.RSA1024 and self.is_fips)
+            if not (alg == ALGO.RSA1024 and
+                    YubiKey.is_fips_version(self.version))
         ]

--- a/ykman/piv.py
+++ b/ykman/piv.py
@@ -1055,16 +1055,12 @@ class PivController(object):
 
     @property
     def supported_algorithms(self):
-        supported = list(ALGO)
-        supported.remove(ALGO.TDES)
+        return [
+            alg for alg in ALGO
 
-        if is_cve201715361_vulnerable_firmware_version(self.version):
-            supported = [alg for alg in supported if not ALGO.is_rsa(alg)]
-
-        if self.version < (4, 0, 0):
-            supported.remove(ALGO.ECCP384)
-
-        if self.is_fips and ALGO.RSA1024 in supported:
-            supported.remove(ALGO.RSA1024)
-
-        return supported
+            if not alg == ALGO.TDES
+            if not (ALGO.is_rsa(alg) and
+                    is_cve201715361_vulnerable_firmware_version(self.version))
+            if not (alg == ALGO.ECCP384 and self.version < (4, 0, 0))
+            if not (alg == ALGO.RSA1024 and self.is_fips)
+        ]

--- a/ykman/piv.py
+++ b/ykman/piv.py
@@ -820,7 +820,7 @@ class PivController(object):
             ).public_key(default_backend())
 
         raise UnsupportedAlgorithm(
-            'Invalid algorithm: %s'.format(algorithm),
+            'Invalid algorithm: {}'.format(algorithm),
             algorithm_id=algorithm)
 
     def generate_self_signed_certificate(


### PR DESCRIPTION
This allows us to tailor the GUI optimally for each kind of YubiKey (i.e., not show options for unsupported algorithms).