### PR TITLE
 Identify PIN-verifiedness state correctly in change-management-key 

### DIFF
--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -732,8 +732,8 @@ def change_management_key(
     if not pin_verified and controller.has_stored_key:
         if pin:
             _verify_pin(ctx, controller, pin, no_prompt=force)
-        else:
-            force or click.confirm(
+        elif not force:
+            click.confirm(
                     'The current management key is stored on the YubiKey'
                     ' and will not be cleared if no PIN is provided. Continue?',
                     abort=True)

--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -713,7 +713,7 @@ def change_management_key(
     """
     controller = ctx.obj['controller']
 
-    _ensure_authenticated(
+    pin_verified = _ensure_authenticated(
         ctx, controller, pin, management_key,
         require_pin_and_key=protect,
         mgm_key_prompt='Enter your current management key '
@@ -729,7 +729,7 @@ def change_management_key(
         ctx.fail('Require touch not supported on this YubiKey.')
 
     # If an old stored key needs to be cleared, the PIN is needed.
-    if not protect and controller.has_stored_key:
+    if not pin_verified and controller.has_stored_key:
         if pin:
             _verify_pin(ctx, controller, pin, no_prompt=force)
         else:

--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -816,17 +816,22 @@ def _ensure_authenticated(
         mgm_key_prompt=None,
         no_prompt=False):
 
+    pin_verified = False
+
     if controller.has_protected_key:
         if not management_key:
-            _verify_pin(ctx, controller, pin, no_prompt=no_prompt)
+            pin_verified = _verify_pin(
+                ctx, controller, pin, no_prompt=no_prompt)
         else:
             _authenticate(ctx, controller, management_key, mgm_key_prompt,
                           no_prompt=no_prompt)
     else:
         if require_pin_and_key:
-            _verify_pin(ctx, controller, pin, no_prompt=no_prompt)
+            pin_verified = _verify_pin(
+                ctx, controller, pin, no_prompt=no_prompt)
         _authenticate(ctx, controller, management_key, mgm_key_prompt,
                       no_prompt=no_prompt)
+    return pin_verified
 
 
 def _verify_pin(ctx, controller, pin, no_prompt=False):
@@ -838,6 +843,7 @@ def _verify_pin(ctx, controller, pin, no_prompt=False):
 
     try:
         controller.verify(pin, touch_callback=prompt_for_touch)
+        return True
     except WrongPin as e:
         ctx.fail('PIN verification failed, {} tries left.'.format(e.tries_left))
     except AuthenticationBlocked as e:


### PR DESCRIPTION
Previously, the following scenario could occur:

 1. Set a protected management key: `ykman piv change-management-key -p`
 2. Run `ykman piv change-management-key`
    - CLI prompts for PIN because mgm key is stored
    - CLI warns that if PIN is not given, stored mgm key will not be
      overwritten

This was because the call to `_ensure_authenticated` would prompt for PIN, but the subsequent `if pin:` statement would not know that `_ensure_authenticated` had prompted for it.