### PR TITLE
Print also confirmation prompts to stderr

### DIFF
--- a/ykman/cli/config.py
+++ b/ykman/cli/config.py
@@ -140,7 +140,7 @@ def set_lock_code(ctx, lock_code, new_lock_code, clear, generate, force):
         click.echo(
             'Using a randomly generated lock code: {}'.format(new_lock_code))
         force or click.confirm(
-            'Lock configuration with this lock code?', abort=True)
+            'Lock configuration with this lock code?', abort=True, err=True)
 
     if dev.config.configuration_locked:
         if lock_code:
@@ -281,7 +281,7 @@ def usb(
         ctx.fail('Configuration is not locked - please remove the '
                  '--lock-code option.')
 
-    force or click.confirm(f_confirm, abort=True)
+    force or click.confirm(f_confirm, abort=True, err=True)
 
     if is_locked and not lock_code:
         lock_code = prompt_lock_code()
@@ -374,7 +374,7 @@ def nfc(ctx, enable, disable, enable_all, disable_all, list, lock_code, force):
         ctx.fail('Configuration is not locked - please remove the '
                  '--lock-code option.')
 
-    force or click.confirm(f_confirm, abort=True)
+    force or click.confirm(f_confirm, abort=True, err=True)
 
     if is_locked and not lock_code:
         lock_code = prompt_lock_code()

--- a/ykman/cli/fido.py
+++ b/ykman/cli/fido.py
@@ -225,7 +225,8 @@ def reset(ctx, force):
     if not force:
         if not click.confirm('WARNING! This will delete all FIDO credentials, '
                              'including FIDO U2F credentials, and restore '
-                             'factory settings. Proceed?'):
+                             'factory settings. Proceed?',
+                             err=True):
             ctx.abort()
 
     def prompt_re_insert_key():

--- a/ykman/cli/mode.py
+++ b/ykman/cli/mode.py
@@ -131,7 +131,7 @@ def mode(ctx, mode, touch_eject, autoeject_timeout, chalresp_timeout, force):
                            .format(mode))
                 ctx.fail('Use --force to attempt to set it anyway.')
             force or click.confirm('Set mode of YubiKey to {}?'.format(mode),
-                                   abort=True)
+                                   abort=True, err=True)
 
         try:
             dev.set_mode(mode, chalresp_timeout, autoeject)

--- a/ykman/cli/oath.py
+++ b/ykman/cli/oath.py
@@ -273,7 +273,8 @@ def _add_cred(ctx, data, force):
     if not force and any(cred.key == key for cred in controller.list()):
         click.confirm(
             'A credential called {} already exists on this YubiKey.'
-            ' Do you want to overwrite it?'.format(data.name), abort=True)
+            ' Do you want to overwrite it?'.format(data.name), abort=True,
+            err=True)
 
     firmware_overwrite_issue = (4, 0, 0) < controller.version < (4, 3, 5)
     cred_is_subset = any(
@@ -417,7 +418,7 @@ def delete(ctx, query, force):
         cred = hits[0]
         if force or (click.confirm(
                 u'Delete credential: {} ?'.format(cred.printable_key),
-                default=False
+                default=False, err=True
         )):
             controller.delete(cred)
             click.echo(u'Deleted {}.'.format(cred.printable_key))

--- a/ykman/cli/opgp.py
+++ b/ykman/cli/opgp.py
@@ -170,7 +170,7 @@ def touch(ctx, key, policy, admin_pin, force):
         ctx.fail('A FIXED policy cannot be changed!')
 
     force or click.confirm('Set touch policy of {.name} key to {.name}?'.format(
-        key, policy), abort=True)
+        key, policy), abort=True, err=True)
     if admin_pin is None:
         admin_pin = click.prompt('Enter admin PIN', hide_input=True, err=True)
     controller.set_touch(key, policy, admin_pin.encode('utf8'))
@@ -198,7 +198,7 @@ def set_pin_retries(ctx, pw_attempts, admin_pin, force):
         click.echo('WARNING: Setting PIN retries will reset the values for all '
                    '3 PINs!')
     force or click.confirm('Set PIN retry counters to: {} {} {}?'.format(
-        *pw_attempts), abort=True)
+        *pw_attempts), abort=True, err=True)
     controller.set_pin_retries(*(pw_attempts + (admin_pin.encode('utf8'),)))
     click.echo('PIN retries successfully set.')
     if resets_pins:

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -82,11 +82,11 @@ def _confirm_slot_overwrite(controller, slot):
     if slot == 1 and slot1:
         click.confirm(
             'Slot 1 is already configured. Overwrite configuration?',
-            abort=True)
+            abort=True, err=True)
     if slot == 2 and slot2:
         click.confirm(
             'Slot 2 is already configured. Overwrite configuration?',
-            abort=True)
+            abort=True, err=True)
 
 
 @click.group()
@@ -215,7 +215,7 @@ def delete(ctx, slot, force):
         ctx.fail('Not possible to delete an empty slot.')
     force or click.confirm(
         'Do you really want to delete'
-        ' the configuration of slot {}?'.format(slot), abort=True)
+        ' the configuration of slot {}?'.format(slot), abort=True, err=True)
     click.echo('Deleting the configuration of slot {}...'.format(slot))
     try:
         controller.zap_slot(slot)
@@ -314,7 +314,7 @@ def yubiotp(ctx, slot, public_id, private_id, key, no_enter, force,
             key = a2b_hex(key)
 
     force or click.confirm('Program an OTP credential in slot {}?'.format(slot),
-                           abort=True)
+                           abort=True, err=True)
     try:
         controller.program_otp(slot, key, public_id, private_id, not no_enter)
     except YkpersError as e:
@@ -425,7 +425,7 @@ def chalresp(ctx, slot, key, totp, touch, force, generate):
 
     cred_type = 'TOTP' if totp else 'challenge-response'
     force or click.confirm('Program a {} credential in slot {}?'
-                           .format(cred_type, slot), abort=True)
+                           .format(cred_type, slot), abort=True, err=True)
     try:
         controller.program_chalresp(slot, key, touch)
     except YkpersError as e:
@@ -515,7 +515,8 @@ def hotp(ctx, slot, key, digits, counter, no_enter, force):
                 click.echo(e)
 
     force or click.confirm(
-        'Program a HOTP credential in slot {}?'.format(slot), abort=True)
+        'Program a HOTP credential in slot {}?'.format(slot), abort=True,
+        err=True)
     try:
         controller.program_hotp(
             slot, key, counter, int(digits) == 8, not no_enter)
@@ -569,7 +570,8 @@ def settings(ctx, slot, new_access_code, delete_access_code, enter, pacing,
 
     force or click.confirm(
         'Update the settings for slot {}? '
-        'All existing settings will be overwritten.'.format(slot), abort=True)
+        'All existing settings will be overwritten.'.format(slot), abort=True,
+        err=True)
     click.echo('Updating settings for slot {}...'.format(slot))
 
     if pacing is not None:

--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -502,7 +502,7 @@ def set_pin_retries(ctx, management_key, pin, pin_retries, puk_retries, force):
     click.echo('WARNING: This will reset the PIN and PUK to the factory '
                'defaults!')
     force or click.confirm('Set PIN and PUK retry counters to: {} {}?'.format(
-        pin_retries, puk_retries), abort=True)
+        pin_retries, puk_retries), abort=True, err=True)
     try:
         controller.set_pin_retries(pin_retries, puk_retries)
         click.echo('Default PINs are set.')
@@ -736,7 +736,7 @@ def change_management_key(
             force or click.confirm(
                     'The current management key is stored on the YubiKey'
                     ' and will not be cleared if no PIN is provided. Continue?',
-                    abort=True)
+                    abort=True, err=True)
 
     if not new_management_key and not protect:
         if generate:
@@ -755,7 +755,7 @@ def change_management_key(
         else:
             new_management_key = click.prompt(
                 'Enter your new management key',
-                hide_input=True, confirmation_prompt=True)
+                hide_input=True, confirmation_prompt=True, err=True)
 
     if new_management_key and type(new_management_key) is not bytes:
         try:


### PR DESCRIPTION
Since e1031c79f311b67b509e735ecf1cb04c84c41d94, all input prompts are written to standard error instead of standard out, but we forgot to do the same for confirmation prompts.