### PR TITLE
piv: add read-object and write-object commands

### DIFF
--- a/test/on_yubikey/cli_piv/test_misc.py
+++ b/test/on_yubikey/cli_piv/test_misc.py
@@ -1,6 +1,5 @@
 from ..util import ykman_cli
-from .util import PivTestCase
-
+from .util import PivTestCase, DEFAULT_MANAGEMENT_KEY
 
 class Misc(PivTestCase):
 
@@ -11,3 +10,11 @@ class Misc(PivTestCase):
     def test_reset(self):
         output = ykman_cli('piv', 'reset', '-f')
         self.assertIn('Success!', output)
+
+    def test_write_read_object(self):
+        ykman_cli(
+            'piv', 'write-object', '--id',
+            '0x5f0001', '-m', DEFAULT_MANAGEMENT_KEY,
+            '-', input='test data')
+        output = ykman_cli('piv', 'read-object', '--id', '0x5f0001')
+        self.assertIn('test data', output)

--- a/test/on_yubikey/cli_piv/test_misc.py
+++ b/test/on_yubikey/cli_piv/test_misc.py
@@ -13,8 +13,8 @@ class Misc(PivTestCase):
 
     def test_write_read_object(self):
         ykman_cli(
-            'piv', 'write-object', '--id',
-            '0x5f0001', '-m', DEFAULT_MANAGEMENT_KEY,
+            'piv', 'write-object',
+            '-m', DEFAULT_MANAGEMENT_KEY,'0x5f0001',
             '-', input='test data')
-        output = ykman_cli('piv', 'read-object', '--id', '0x5f0001')
+        output = ykman_cli('piv', 'read-object', '0x5f0001')
         self.assertEquals('test data\n', output)

--- a/test/on_yubikey/cli_piv/test_misc.py
+++ b/test/on_yubikey/cli_piv/test_misc.py
@@ -17,4 +17,4 @@ class Misc(PivTestCase):
             '0x5f0001', '-m', DEFAULT_MANAGEMENT_KEY,
             '-', input='test data')
         output = ykman_cli('piv', 'read-object', '--id', '0x5f0001')
-        self.assertIn('test data', output)
+        self.assertEquals('test data\n', output)

--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -833,9 +833,11 @@ def read_object(ctx, pin, object_id):
 @click.argument('data', type=click.File('rb'), metavar='DATA')
 def write_object(ctx, pin, management_key, object_id, data):
     """
-    Write  arbitrary PIV object.
+    Write an arbitrary PIV object.
 
-    Write PIV object by providing the object id.
+    Write a PIV object by providing the object id.
+    Yubico writable PIV objects are available in
+    the range 5f0000 - 5fffff.
     """
 
     controller = ctx.obj['controller']
@@ -845,11 +847,13 @@ def write_object(ctx, pin, management_key, object_id, data):
         try:
             controller.put_data(object_id, data.read())
         except APDUError as e:
+            logger.debug('Failed writing object', exc_info=e)
             if e.sw == SW.INCORRECT_PARAMETERS:
-                ctx.fail('Something went wrong.')
+                ctx.fail('Something went wrong, is the object id valid?')
             raise
 
     do_write_object()
+
 
 def _prompt_management_key(
         ctx, prompt='Enter a management key [blank to use default key]'):

--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -810,7 +810,7 @@ def read_object(ctx, pin, object_id):
 
     def do_read_object(retry=True):
         try:
-            click.echo(b2a_hex(controller.get_data(object_id)))
+            click.echo(controller.get_data(object_id))
         except APDUError as e:
             if e.sw == SW.NOT_FOUND:
                 ctx.fail('No data found.')

--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -795,15 +795,18 @@ def unblock_pin(ctx, puk, new_pin):
 @piv.command('read-object')
 @click_pin_option
 @click.pass_context
-@click.option(
-        '-i', '--id', 'object_id',
-        callback=lambda ctx, param, value: int(value, 16),
-        metavar='HEX', help='Id of PIV object.', required=True)
+@click.argument(
+    'object-id',
+    callback=lambda ctx, param, value: int(value, 16),
+    metavar='OBJECT-ID')
 def read_object(ctx, pin, object_id):
     """
     Read arbitrary PIV object.
 
     Read PIV object by providing the object id.
+
+    \b
+    OBJECT-ID       Id of PIV object in HEX.
     """
 
     controller = ctx.obj['controller']
@@ -826,10 +829,10 @@ def read_object(ctx, pin, object_id):
 @click_pin_option
 @click_management_key_option
 @click.pass_context
-@click.option(
-        '-i', '--id', 'object_id',
-        callback=lambda ctx, param, value: int(value, 16),
-        metavar='HEX', help='Id of PIV object.', required=True)
+@click.argument(
+    'object-id',
+    callback=lambda ctx, param, value: int(value, 16),
+    metavar='OBJECT-ID')
 @click.argument('data', type=click.File('rb'), metavar='DATA')
 def write_object(ctx, pin, management_key, object_id, data):
     """
@@ -838,6 +841,10 @@ def write_object(ctx, pin, management_key, object_id, data):
     Write a PIV object by providing the object id.
     Yubico writable PIV objects are available in
     the range 5f0000 - 5fffff.
+
+    \b
+    OBJECT-ID       Id of PIV object in HEX.
+    DATA            File containing the data to be written. Use '-' to use stdin.
     """
 
     controller = ctx.obj['controller']

--- a/ykman/piv.py
+++ b/ykman/piv.py
@@ -810,9 +810,10 @@ class PivController(object):
         id_bytes = struct.pack(b'>I', object_id).lstrip(b'\0')
         tlv = Tlv(self.send_cmd(INS.GET_DATA, 0x3f, 0xff,
                                 Tlv(TAG.OBJ_ID, id_bytes)))
-        if tlv.tag != TAG.OBJ_DATA:
+        if tlv.tag not in [TAG.OBJ_DATA, OBJ.DISCOVERY]:
             raise ValueError('Wrong tag in response data!')
         return tlv.value
+
 
     def put_data(self, object_id, data):
         id_bytes = struct.pack(b'>I', object_id).lstrip(b'\0')


### PR DESCRIPTION
Add commands for writing and reading arbitrary PIV objects. The read commands should prompt for the pin if needed the write command should prompt for pin or management key if needed.

requested in #183