### PR TITLE
opengp touch changes

### DIFF
--- a/ykman/cli/opgp.py
+++ b/ykman/cli/opgp.py
@@ -181,7 +181,6 @@ def touch(ctx, key, policy, admin_pin, force):
     if admin_pin is None:
         admin_pin = click.prompt('Enter admin PIN', hide_input=True, err=True)
     controller.set_touch(key, policy, admin_pin.encode('utf8'))
-    click.echo('Touch policy successfully set.')
 
 
 @openpgp.command('set-pin-retries')

--- a/ykman/cli/opgp.py
+++ b/ykman/cli/opgp.py
@@ -39,15 +39,15 @@ logger = logging.getLogger(__name__)
 
 
 KEY_NAMES = dict(
-    sig=KEY_SLOT.SIGN,
-    enc=KEY_SLOT.ENCRYPT,
-    aut=KEY_SLOT.AUTHENTICATE
+    sig=KEY_SLOT.SIGNATURE,
+    enc=KEY_SLOT.ENCRYPTION,
+    aut=KEY_SLOT.AUTHENTICATION
 )
 
 MODE_NAMES = dict(
     off=TOUCH_MODE.OFF,
     on=TOUCH_MODE.ON,
-    fixed=TOUCH_MODE.ON_FIXED
+    fixed=TOUCH_MODE.FIXED
 )
 
 

--- a/ykman/cli/opgp.py
+++ b/ykman/cli/opgp.py
@@ -116,6 +116,17 @@ def info(ctx):
     click.echo('PIN tries remaining: {}'.format(retries.pin))
     click.echo('Reset code tries remaining: {}'.format(retries.reset))
     click.echo('Admin PIN tries remaining: {}'.format(retries.admin))
+    click.echo()
+    click.echo('Touch policies')
+    click.echo(
+        'Signature key           {.name}'.format(
+            controller.get_touch(KEY_SLOT.SIGNATURE)))
+    click.echo(
+        'Encryption key          {.name}'.format(
+            controller.get_touch(KEY_SLOT.ENCRYPTION)))
+    click.echo(
+        'Authentication key      {.name}'.format(
+            controller.get_touch(KEY_SLOT.AUTHENTICATION)))
 
 
 @openpgp.command()

--- a/ykman/cli/opgp.py
+++ b/ykman/cli/opgp.py
@@ -167,17 +167,13 @@ def touch(ctx, key, policy, admin_pin, force):
     Manage touch policy for OpenPGP keys.
 
     \b
-    KEY     Key slot to get/set (sig, enc or aut).
+    KEY     Key slot to set (sig, enc or aut).
     POLICY  Touch policy to set (on, off or fixed).
     """
     controller = ctx.obj['controller']
     old_policy = controller.get_touch(key)
-    click.echo('Current touch policy of {.name} key is {.name}.'.format(
-        key, old_policy))
-    if policy is None:
-        return
 
-    if old_policy == TOUCH_MODE.ON_FIXED:
+    if old_policy == TOUCH_MODE.FIXED:
         ctx.fail('A FIXED policy cannot be changed!')
 
     force or click.confirm('Set touch policy of {.name} key to {.name}?'.format(

--- a/ykman/cli/opgp.py
+++ b/ykman/cli/opgp.py
@@ -154,10 +154,10 @@ def echo_default_pins():
 
 
 @openpgp.command()
-@click.argument('key', type=click.Choice(sorted(KEY_NAMES)),
+@click.argument('key', metavar='KEY', type=click.Choice(sorted(KEY_NAMES)),
                 callback=lambda c, p, k: KEY_NAMES.get(k))
-@click.argument('policy', type=click.Choice(sorted(MODE_NAMES)),
-                callback=lambda c, p, k: MODE_NAMES.get(k), required=False)
+@click.argument('policy', metavar='POLICY', type=click.Choice(sorted(MODE_NAMES)),
+                callback=lambda c, p, k: MODE_NAMES.get(k))
 @click.option('--admin-pin', required=False, metavar='PIN',
               help='Admin PIN for OpenPGP.')
 @click_force_option

--- a/ykman/opgp.py
+++ b/ykman/opgp.py
@@ -37,16 +37,16 @@ from collections import namedtuple
 
 @unique
 class KEY_SLOT(IntEnum):  # noqa: N801
-    SIGN = 0xd6
-    ENCRYPT = 0xd7
-    AUTHENTICATE = 0xd8
+    SIGNATURE = 0xd6
+    ENCRYPTION = 0xd7
+    AUTHENTICATION = 0xd8
 
 
 @unique
 class TOUCH_MODE(IntEnum):  # noqa: N801
     OFF = 0x00
     ON = 0x01
-    ON_FIXED = 0x02
+    FIXED = 0x02
 
 
 @unique


### PR DESCRIPTION
Suggested changes:
- Print touch policies in info command (as requested in #203)
- Rename enum names to be more human friendly, as they are printed to the user
- Don't give a success message (most other ykman commands stay silent on success)
- Make the touch command set-only (use info for getting current status)
- Give meaningful names to the metavars (printed in the help)