### PR TITLE
parse_certs: fail on empty list

### DIFF
--- a/ykman/util.py
+++ b/ykman/util.py
@@ -473,7 +473,9 @@ def parse_certificates(data, password):
                         PEM_IDENTIFIER + cert, default_backend()))
             except Exception:
                 pass
-        return certs
+        # Could be valid PEM but not certificates.
+        if len(certs) > 0:
+            return certs
 
     # PKCS12
     if is_pkcs12(data):


### PR DESCRIPTION
`ykman.util.parse_certificates` returned an empty list on pem files without certificates (such as private keys). This leads to problems in yubikey-manager-qt, where this would be interpreted as the data containing certificates.