### PR TITLE
Fix how the context is resolved

### DIFF
--- a/ykman/cli/util.py
+++ b/ykman/cli/util.py
@@ -81,7 +81,7 @@ class YkmanContextObject(MutableMapping):
     def resolve(self):
         if not self._resolved:
             self._resolved = True
-            for k, f in self._objects.items():
+            for k, f in self._objects.copy().items():
                 self._objects[k] = f()
 
     def __getitem__(self, key):


### PR DESCRIPTION
On Python3 dict.items() returns a view object and changing dictionary
values while iterating this view may lead to unexpected results when we
resolve the context like an attempt to resolve the same object twice.

This patch fixes this by creating a copy of the underlying dict in the
resolve() method.