### PR TITLE
add support fort listing smart card readers

### DIFF
--- a/ykman/cli/__main__.py
+++ b/ykman/cli/__main__.py
@@ -32,7 +32,7 @@ from ykman import __version__
 from ..util import TRANSPORT, Cve201715361VulnerableError, YUBIKEY
 from ..native.pyusb import get_usb_backend_version
 from ..driver_otp import libversion as ykpers_version
-from ..driver_ccid import open_devices as open_ccid
+from ..driver_ccid import open_devices as open_ccid, list_readers
 from ..device import YubiKey
 from ..descriptor import (get_descriptors, list_devices, open_device,
                           FailedOpeningDeviceException, Descriptor)
@@ -194,11 +194,17 @@ def cli(ctx, device, log_level, log_file, reader):
 @cli.command('list')
 @click.option('-s', '--serials', is_flag=True, help='Output only serial '
               'numbers, one per line (devices without serial will be omitted).')
+@click.option('-r', '--readers', is_flag=True, help='List available smart card readers.')
 @click.pass_context
-def list_keys(ctx, serials):
+def list_keys(ctx, serials, readers):
     """
     List connected YubiKeys.
     """
+    if readers:
+        for reader in list_readers():
+            click.echo(reader.name)
+        ctx.exit()
+
     all_descriptors = get_descriptors()
     descriptors = [d for d in all_descriptors if d.key_type != YUBIKEY.SKY]
     skys = len(all_descriptors) - len(descriptors)

--- a/ykman/driver_ccid.py
+++ b/ykman/driver_ccid.py
@@ -323,7 +323,7 @@ def open_devices(name_filter=YK_READER_NAME):
     while readers:
         try_again = []
         for reader in readers:
-            if reader.name.lower().startswith(name_filter.lower()):
+            if name_filter.lower() in reader.name.lower():
                 try:
                     conn = reader.createConnection()
                     conn.connect()

--- a/ykman/driver_ccid.py
+++ b/ykman/driver_ccid.py
@@ -307,7 +307,7 @@ def kill_scdaemon():
     return killed
 
 
-def _list_readers():
+def list_readers():
     try:
         return System.readers()
     except ListReadersException:
@@ -319,7 +319,7 @@ def _list_readers():
 
 
 def open_devices(name_filter=YK_READER_NAME):
-    readers = _list_readers()
+    readers = list_readers()
     while readers:
         try_again = []
         for reader in readers:


### PR DESCRIPTION
- add `-r/--reader` flag to ykman list, for listing available smart card readers (both yubikeys and external)
- relax the filtering, so that it's possible to select reader with any substring of the reader name. For example `OMNI` would now work on a `HID Global OMNIKEY 5022 Smart Card Reader` reader, before `HID` was required.