### PR TITLE
config: accept opengp as OPGP

### DIFF
--- a/test/on_yubikey/test_cli_config.py
+++ b/test/on_yubikey/test_cli_config.py
@@ -30,6 +30,11 @@ class TestConfigUSB(DestructiveYubikeyTestCase):
         output = ykman_cli('config', 'usb', '--list')
         self.assertNotIn('OpenPGP', output)
 
+    def test_disable_openpgp_alternative_syntax(self):
+        ykman_cli('config', 'usb', '--disable', 'openpgp', '-f')
+        output = ykman_cli('config', 'usb', '--list')
+        self.assertNotIn('OpenPGP', output)
+
     def test_disable_piv(self):
         ykman_cli('config', 'usb', '--disable', 'PIV', '-f')
         output = ykman_cli('config', 'usb', '--list')

--- a/ykman/cli/config.py
+++ b/ykman/cli/config.py
@@ -27,8 +27,7 @@
 
 from __future__ import absolute_import
 
-from .util import (
-    click_postpone_execution, click_force_option, ApplicationsChoice)
+from .util import click_postpone_execution, click_force_option, UpperCaseChoice
 from ..device import device_config, FLAGS
 from ..util import APPLICATION
 from binascii import a2b_hex, b2a_hex
@@ -41,6 +40,15 @@ logger = logging.getLogger(__name__)
 
 
 CLEAR_LOCK_CODE = '0' * 32
+
+
+class ApplicationsChoice(UpperCaseChoice):
+    """
+    Special version of UpperCaseChoice that accepts openpgp as OPGP
+    """
+    def convert(self, value, param, ctx):
+        return 'OPGP' if value.lower() == 'openpgp' \
+            else super().convert(value, param, ctx)
 
 
 def prompt_lock_code(prompt='Enter your lock code'):

--- a/ykman/cli/config.py
+++ b/ykman/cli/config.py
@@ -27,7 +27,8 @@
 
 from __future__ import absolute_import
 
-from .util import click_postpone_execution, click_force_option, UpperCaseChoice
+from .util import (
+    click_postpone_execution, click_force_option, ApplicationsChoice)
 from ..device import device_config, FLAGS
 from ..util import APPLICATION
 from binascii import a2b_hex, b2a_hex
@@ -174,10 +175,10 @@ def set_lock_code(ctx, lock_code, new_lock_code, clear, generate, force):
 @click.pass_context
 @click_force_option
 @click.option(
-    '-e', '--enable', multiple=True, type=UpperCaseChoice(
+    '-e', '--enable', multiple=True, type=ApplicationsChoice(
         APPLICATION.__members__.keys()), help='Enable applications.')
 @click.option(
-    '-d', '--disable', multiple=True, type=UpperCaseChoice(
+    '-d', '--disable', multiple=True, type=ApplicationsChoice(
         APPLICATION.__members__.keys()), help='Disable applications.')
 @click.option('-l', '--list', is_flag=True, help='List enabled applications.')
 @click.option(
@@ -307,10 +308,10 @@ def usb(
 @click.pass_context
 @click_force_option
 @click.option(
-    '-e', '--enable', multiple=True, type=UpperCaseChoice(
+    '-e', '--enable', multiple=True, type=ApplicationsChoice(
         APPLICATION.__members__.keys()), help='Enable applications.')
 @click.option(
-    '-d', '--disable', multiple=True, type=UpperCaseChoice(
+    '-d', '--disable', multiple=True, type=ApplicationsChoice(
         APPLICATION.__members__.keys()), help='Disable applications.')
 @click.option(
     '-a', '--enable-all', is_flag=True, help='Enable all applications.')

--- a/ykman/cli/util.py
+++ b/ykman/cli/util.py
@@ -53,6 +53,15 @@ class UpperCaseChoice(click.Choice):
                 value, ', '.join(self.choices)), param, ctx)
 
 
+class ApplicationsChoice(UpperCaseChoice):
+    """
+    Special version of UpperCaseChoice that accepts openpgp as OPGP
+    """
+    def convert(self, value, param, ctx):
+        return 'OPGP' if value.lower() == 'openpgp' \
+            else super().convert(value, param, ctx)
+
+
 def click_callback(invoke_on_missing=False):
     def wrap(f):
         @functools.wraps(f)

--- a/ykman/cli/util.py
+++ b/ykman/cli/util.py
@@ -53,15 +53,6 @@ class UpperCaseChoice(click.Choice):
                 value, ', '.join(self.choices)), param, ctx)
 
 
-class ApplicationsChoice(UpperCaseChoice):
-    """
-    Special version of UpperCaseChoice that accepts openpgp as OPGP
-    """
-    def convert(self, value, param, ctx):
-        return 'OPGP' if value.lower() == 'openpgp' \
-            else super().convert(value, param, ctx)
-
-
 def click_callback(invoke_on_missing=False):
     def wrap(f):
         @functools.wraps(f)


### PR DESCRIPTION
A small hack to accept `openpgp` as an option for the `ykman config` commands, without renaming the enum. Initially tried with a callback, but the type is handled before that in click.