### PR TITLE
piv: improve piv info command

### DIFF
--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -531,7 +531,7 @@ def set_pin_retries(ctx, management_key, pin, pin_retries, puk_retries, force):
 @click.argument('public-key', type=click.File('rb'), metavar='PUBLIC-KEY')
 @click.option(
     '-s', '--subject',
-    help='A subject name for the certificate.', required=True)
+    help='Subject common name (CN) for the certificate.', required=True)
 @click.option(
     '-d', '--valid-days',
     help='Number of days until the certificate expires.',
@@ -578,7 +578,7 @@ def generate_certificate(
 @click.argument('csr-output', type=click.File('wb'), metavar='CSR')
 @click.option(
     '-s', '--subject',
-    help='A subject name for the requested certificate.', required=True)
+    help='Subject common name (CN) for the requested certificate.', required=True)
 def generate_certificate_signing_request(
         ctx, slot, pin, public_key, csr_output, subject):
     """

--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -176,7 +176,7 @@ def info(ctx):
         try:
             click.echo('\tSubject DN:\t%s' % cert.subject.rfc4514_string())
             click.echo('\tIssuer DN:\t%s' % cert.issuer.rfc4514_string())
-        except Exception:
+        except AttributeError:
             logger.debug('Failed to read DN, falling back to only CNs')
             cn = cert.subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME)
             cn = cn[0].value if len(cn) > 0 else 'None'

--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -170,12 +170,21 @@ def info(ctx):
         click.echo('Slot %02x:' % slot)
         click.echo('\tAlgorithm:\t%s' % ALGO.from_public_key(cert.public_key())
                    .name)
-        cn = cert.subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME)
-        cn = cn[0].value if len(cn) > 0 else 'None'
-        click.echo('\tSubject CN:\t%s' % cn)
-        cn = cert.issuer.get_attributes_for_oid(x509.NameOID.COMMON_NAME)
-        cn = cn[0].value if len(cn) > 0 else 'None'
-        click.echo('\tIssuer CN:\t%s' % cn)
+
+        # Try to print out full DN, fallback to only CN.
+        # Support for DN was added in crytography 2.5
+        try:
+            click.echo('\tSubject DN:\t%s' % cert.subject.rfc4514_string())
+            click.echo('\tIssuer DN:\t%s' % cert.issuer.rfc4514_string())
+        except:
+            logger.debug('Failed to read DN, falling back to only CNs')
+            cn = cert.subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME)
+            cn = cn[0].value if len(cn) > 0 else 'None'
+            click.echo('\tSubject CN:\t%s' % cn)
+            cn = cert.issuer.get_attributes_for_oid(x509.NameOID.COMMON_NAME)
+            cn = cn[0].value if len(cn) > 0 else 'None'
+            click.echo('\tIssuer CN:\t%s' % cn)
+
         click.echo('\tSerial:\t\t%s' % cert.serial_number)
         click.echo('\tFingerprint:\t%s' % b2a_hex(
             cert.fingerprint(hashes.SHA256())).decode('ascii'))

--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -176,7 +176,7 @@ def info(ctx):
         try:
             click.echo('\tSubject DN:\t%s' % cert.subject.rfc4514_string())
             click.echo('\tIssuer DN:\t%s' % cert.issuer.rfc4514_string())
-        except:
+        except Exception:
             logger.debug('Failed to read DN, falling back to only CNs')
             cn = cert.subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME)
             cn = cn[0].value if len(cn) > 0 else 'None'

--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -176,6 +176,7 @@ def info(ctx):
         cn = cert.issuer.get_attributes_for_oid(x509.NameOID.COMMON_NAME)
         cn = cn[0].value if len(cn) > 0 else 'None'
         click.echo('\tIssuer CN:\t%s' % cn)
+        click.echo('\tSerial:\t\t%s' % cert.serial_number)
         click.echo('\tFingerprint:\t%s' % b2a_hex(
             cert.fingerprint(hashes.SHA256())).decode('ascii'))
         click.echo('\tNot before:\t%s' % cert.not_valid_before)


### PR DESCRIPTION
- print the serial number of the certificate in `piv info`
- cryptography 2.5 added support for reading full DN strings from certificates, try to use that in `piv info` if available. Fall back to old behavior if its not. 
- clarify in help-texts that the `--subject` option is for the subject common name
