### PR TITLE
Fix fallback logic in piv info for cryptogtaphy versions < 2.5

### DIFF
--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -163,11 +163,12 @@ def info(ctx):
             issuer_dn = cert.issuer.rfc4514_string()
             print_dn = True
         except AttributeError:
+            print_dn = False
             logger.debug('Failed to read DN, falling back to only CNs')
             subject_cn = cert.subject.get_attributes_for_oid(x509.NameOID.COMMON_NAME)
-            subject_cn = subject_cn[0].value if len(cn) > 0 else 'None'
+            subject_cn = subject_cn[0].value if subject_cn else 'None'
             issuer_cn = cert.issuer.get_attributes_for_oid(x509.NameOID.COMMON_NAME)
-            issuer_cn = issuer_cn[0].value if len(cn) > 0 else 'None'
+            issuer_cn = issuer_cn[0].value if issuer_cn else 'None'
         except ValueError as e:
             # Malformed certificates may throw ValueError
             logger.debug('Failed parsing certificate', exc_info=e)

--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -182,7 +182,7 @@ def info(ctx):
         not_after = cert.not_valid_after
 
         # Print out everything
-        click.echo('\tAlgorithm:\t%s' % algo)
+        click.echo('\tAlgorithm:\t%s' % algo.name)
         if print_dn:
             click.echo('\tSubject DN:\t%s' % subject_dn)
             click.echo('\tIssuer DN:\t%s' % issuer_dn)


### PR DESCRIPTION
- fixes #230 (the bug mentioned in the thread, not specifying the version)
- also print the algo name correctly