### PR TITLE
Add `--upload` feature to `otp yubiotp` command

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ import os
 from setuptools import setup
 
 install_requires = [
-    'six', 'pyscard', 'pyusb', 'click', 'cryptography', 'pyopenssl', 'fido2'
+    'six', 'pyscard', 'pyusb', 'click', 'cryptography', 'pyopenssl', 'fido2',
+    'requests'
 ]
 tests_require = []
 if sys.version_info < (3, 3):

--- a/setup.py
+++ b/setup.py
@@ -30,8 +30,7 @@ import os
 from setuptools import setup
 
 install_requires = [
-    'six', 'pyscard', 'pyusb', 'click', 'cryptography', 'pyopenssl', 'fido2',
-    'requests'
+    'six', 'pyscard', 'pyusb', 'click', 'cryptography', 'pyopenssl', 'fido2'
 ]
 tests_require = []
 if sys.version_info < (3, 3):

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -41,6 +41,7 @@ import logging
 import os
 import struct
 import click
+import webbrowser
 
 
 logger = logging.getLogger(__name__)
@@ -331,6 +332,7 @@ def yubiotp(ctx, slot, public_id, private_id, key, no_enter, force,
         if upload_result['success']:
             click.echo('Upload to YubiCloud initiated successfully. '
                        'Please finish the upload procedure in your browser.')
+            webbrowser.open_new_tab(upload_result['url'])
             click.echo('If the browser did not open automatically, '
                        'open this URL manually: ' + upload_result['url'])
         else:

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -356,10 +356,9 @@ def yubiotp(ctx, slot, public_id, private_id, key, no_enter, force,
 
     if upload:
         if upload_result['success']:
-            click.echo('Please finish the upload procedure in your browser.')
+            click.echo('Opening upload form in browser: '
+                       + upload_result['url'])
             webbrowser.open_new_tab(upload_result['url'])
-            click.echo('If the browser did not open automatically, '
-                       'open this URL manually: ' + upload_result['url'])
 
 
 @otp.command()

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -344,8 +344,7 @@ def yubiotp(ctx, slot, public_id, private_id, key, no_enter, force,
                     .format(upload_result['status'], upload_result['content']),
                     err=True
                 )
-            ctx.fail('Upload to YubiCloud failed. '
-                     'YubiKey slot was NOT programmed.')
+            ctx.fail('Upload to YubiCloud failed.')
 
     force or click.confirm('Program an OTP credential in slot {}?'.format(slot),
                            abort=True, err=True)

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -34,6 +34,7 @@ from ..util import (
     TRANSPORT, generate_static_pw, modhex_decode,
     modhex_encode, parse_key, parse_b32_key)
 from binascii import a2b_hex, b2a_hex
+from .. import __version__
 from ..driver_otp import YkpersError
 from ..otp import OtpController, PrepareUploadFailed
 from ..scancodes import KEYBOARD_LAYOUT
@@ -327,7 +328,8 @@ def yubiotp(ctx, slot, public_id, private_id, key, no_enter, force,
     if upload:
         try:
             upload_url = controller.prepare_upload_key(
-                key, public_id, private_id, serial=dev.serial)
+                key, public_id, private_id, serial=dev.serial,
+                user_agent='ykman/' + __version__)
             click.echo('Upload to YubiCloud initiated successfully.')
         except PrepareUploadFailed as e:
             if e.errors:

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -344,15 +344,16 @@ def yubiotp(ctx, slot, public_id, private_id, key, no_enter, force,
         else:
             if 'errors' in upload_result:
                 for k, v in upload_result['errors'].items():
-                    click.echo('%s: %s' % (k, v))
+                    click.echo('%s: %s' % (k, v), err=True)
             elif upload_result.get('error') == 'connection_failed':
-                click.echo('Failed to open HTTPS connection.')
+                click.echo('Failed to open HTTPS connection.', err=True)
             elif upload_result.get('status') == 404:
-                click.echo('Upload request not recognized by server.')
+                click.echo('Upload request not recognized by server.', err=True)
             else:
                 click.echo(
                     'Upload request failed with status {}: {}'
-                    .format(upload_result['status'], upload_result['content'])
+                    .format(upload_result['status'], upload_result['content']),
+                    err=True
                 )
             ctx.fail('Upload to YubiCloud failed. '
                      'YubiKey slot was NOT programmed.')

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -342,8 +342,6 @@ def yubiotp(ctx, slot, public_id, private_id, key, no_enter, force,
             click.echo('If the browser did not open automatically, '
                        'open this URL manually: ' + upload_result['url'])
         else:
-            click.echo('ERROR: Upload to YubiCloud failed. '
-                       'YubiKey slot was NOT programmed.')
             if 'errors' in upload_result:
                 for k, v in upload_result['errors'].items():
                     click.echo('%s: %s' % (k, v))
@@ -351,6 +349,8 @@ def yubiotp(ctx, slot, public_id, private_id, key, no_enter, force,
                 click.echo('Failed to open HTTPS connection.')
             else:
                 click.echo(upload_result['content'])
+            ctx.fail('Upload to YubiCloud failed. '
+                     'YubiKey slot was NOT programmed.')
 
 
 @otp.command()

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -332,18 +332,8 @@ def yubiotp(ctx, slot, public_id, private_id, key, no_enter, force,
                 user_agent='ykman/' + __version__)
             click.echo('Upload to YubiCloud initiated successfully.')
         except PrepareUploadFailed as e:
-            if e.errors:
-                if 'connection_failed' in e.errors:
-                    ctx.fail('Failed to open HTTPS connection.')
-                else:
-                    error_msg = '\n'.join([
-                        '{}: {}'.format(k, v) for k, v in e.errors.items()])
-                    ctx.fail('Upload to YubiCloud failed.\n' + error_msg)
-            elif e.status == 404:
-                ctx.fail('Upload request not recognized by server.')
-            else:
-                ctx.fail(
-                    'Upload request failed with status {}.'.format(e.status))
+            error_msg = '\n'.join(e.messages())
+            ctx.fail('Upload to YubiCloud failed.\n' + error_msg)
 
     force or click.confirm('Program an OTP credential in slot {}?'.format(slot),
                            abort=True, err=True)

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -338,6 +338,8 @@ def yubiotp(ctx, slot, public_id, private_id, key, no_enter, force,
             if 'errors' in upload_result:
                 for k, v in upload_result['errors'].items():
                     click.echo('%s: %s' % (k, v))
+            elif upload_result.get('error') == 'connection_failed':
+                click.echo('Failed to open HTTPS connection.')
             else:
                 click.echo(upload_result['content'])
 

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -326,7 +326,7 @@ def yubiotp(ctx, slot, public_id, private_id, key, no_enter, force,
                                abort=False, err=True)
     if upload:
         upload_result = controller.prepare_upload_key(
-            key, public_id, private_id)
+            key, public_id, private_id, serial=dev.serial)
 
         if upload_result['success']:
             click.echo('Upload to YubiCloud initiated successfully.')

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -245,7 +245,7 @@ def delete(ctx, slot, force):
     help='Generate a random secret key. Conflicts with --key.')
 @click.option(
     '-u', '--upload', is_flag=True, required=False,
-    help='Upload secret key to YubiCloud (opens in browser). '
+    help='Upload credential to YubiCloud (opens in browser). '
     'Conflicts with --force.')
 @click_force_option
 @click.pass_context

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -244,7 +244,7 @@ def delete(ctx, slot, force):
     '-G', '--generate-key', is_flag=True, required=False,
     help='Generate a random secret key. Conflicts with --key.')
 @click.option(
-    '--upload', is_flag=True, required=False,
+    '-u', '--upload', is_flag=True, required=False,
     help='Upload secret key to YubiCloud (opens in browser)')
 @click_force_option
 @click.pass_context

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -347,8 +347,13 @@ def yubiotp(ctx, slot, public_id, private_id, key, no_enter, force,
                     click.echo('%s: %s' % (k, v))
             elif upload_result.get('error') == 'connection_failed':
                 click.echo('Failed to open HTTPS connection.')
+            elif upload_result.get('status') == 404:
+                click.echo('Upload request not recognized by server.')
             else:
-                click.echo(upload_result['content'])
+                click.echo(
+                    'Upload request failed with status {}: {}'
+                    .format(upload_result['status'], upload_result['content'])
+                )
             ctx.fail('Upload to YubiCloud failed. '
                      'YubiKey slot was NOT programmed.')
 

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -328,7 +328,8 @@ def yubiotp(ctx, slot, public_id, private_id, key, no_enter, force,
         _failed_to_write_msg(ctx, e)
 
     if upload:
-        upload_result = controller.upload_key(key, public_id, private_id)
+        upload_result = controller.prepare_upload_key(
+            key, public_id, private_id)
         if upload_result['success']:
             click.echo('Upload to YubiCloud initiated successfully. '
                        'Please finish the upload procedure in your browser.')

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -131,7 +131,7 @@ class OtpController(object):
         finally:
             ykpers.ykp_free_config(cfg)
 
-    def upload_key(self, key, public_id, private_id):
+    def prepare_upload_key(self, key, public_id, private_id):
         serial_ref = c_uint()
         if ykpers.yk_get_serial(self._dev, 0, 0, byref(serial_ref)):
             serial = serial_ref.value

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -27,11 +27,11 @@
 
 from __future__ import absolute_import
 
-import http.client
 import json
 import logging
 import time
 from ctypes import sizeof, byref, c_uint, create_string_buffer
+from six.moves import http_client
 from .driver_otp import ykpers, check, YkpersError
 from .util import (time_challenge, parse_totp_hash, format_code,
                    hmac_shorten_key, modhex_encode)
@@ -151,7 +151,7 @@ class OtpController(object):
             'private_id': b2a_hex(private_id).decode('utf-8'),
         }
 
-        httpconn = http.client.HTTPSConnection(UPLOAD_HOST, timeout=1)
+        httpconn = http_client.HTTPSConnection(UPLOAD_HOST, timeout=1)
         try:
             httpconn.request('POST', UPLOAD_PATH,
                              body=json.dumps(data, indent=False, sort_keys=True)

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -37,6 +37,7 @@ from .driver_otp import ykpers, check, YkpersError
 from .util import (time_challenge, parse_totp_hash, format_code,
                    hmac_shorten_key, modhex_encode)
 from .scancodes import encode, KEYBOARD_LAYOUT
+from . import __version__
 from enum import IntEnum, unique
 from binascii import a2b_hex, b2a_hex
 
@@ -151,7 +152,11 @@ class OtpController(object):
             httpconn.request('POST', UPLOAD_PATH,
                              body=json.dumps(data, indent=False, sort_keys=True)
                              .encode('utf-8'),
-                             headers={'Content-Type': 'application/json'})
+                             headers={
+                                 'Content-Type': 'application/json',
+                                 'User-Agent':
+                                 'python-yubikey-manager/' + __version__,
+                             })
         except Exception as e:
             logger.error('Failed to connect to %s', UPLOAD_HOST, exc_info=e)
             return {'success': False, 'error': 'connection_failed'}

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -160,8 +160,6 @@ class OtpController(object):
         resp = httpconn.getresponse()
         if resp.status == 200:
             url = json.loads(resp.read().decode('utf-8'))['finish_url']
-            url += '?serial=' + str(serial)
-            url += '&prefix=' + modhex_public_id
             webbrowser.open_new_tab(url)
             return {'success': True, 'url': url}
         else:

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -140,10 +140,10 @@ class OtpController(object):
 
         modhex_public_id = modhex_encode(public_id)
         data = {
-            'aeskey': binascii.b2a_hex(key).decode('utf-8'),
+            'aes_key': binascii.b2a_hex(key).decode('utf-8'),
             'serial': serial,
-            'prefix': modhex_public_id,
-            'uid': binascii.b2a_hex(private_id).decode('utf-8'),
+            'public_id': modhex_public_id,
+            'private_id': binascii.b2a_hex(private_id).decode('utf-8'),
         }
 
         httpconn = http.client.HTTPSConnection(UPLOAD_HOST, timeout=1)

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -32,7 +32,6 @@ import http.client
 import json
 import logging
 import time
-import webbrowser
 from ctypes import sizeof, byref, c_uint, create_string_buffer
 from .driver_otp import ykpers, check, YkpersError
 from .util import (time_challenge, parse_totp_hash, format_code,
@@ -160,7 +159,6 @@ class OtpController(object):
         resp = httpconn.getresponse()
         if resp.status == 200:
             url = json.loads(resp.read().decode('utf-8'))['finish_url']
-            webbrowser.open_new_tab(url)
             return {'success': True, 'url': url}
         else:
             resp_body = resp.read()

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -141,7 +141,8 @@ class OtpController(object):
         finally:
             ykpers.ykp_free_config(cfg)
 
-    def prepare_upload_key(self, key, public_id, private_id, serial=None):
+    def prepare_upload_key(self, key, public_id, private_id, serial=None,
+                           user_agent='python-yubikey-manager/' + __version__):
         modhex_public_id = modhex_encode(public_id)
         data = {
             'aes_key': b2a_hex(key).decode('utf-8'),
@@ -157,8 +158,7 @@ class OtpController(object):
                              .encode('utf-8'),
                              headers={
                                  'Content-Type': 'application/json',
-                                 'User-Agent':
-                                 'python-yubikey-manager/' + __version__,
+                                 'User-Agent': user_agent,
                              })
         except Exception as e:
             logger.error('Failed to connect to %s', UPLOAD_HOST, exc_info=e)

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -73,9 +73,9 @@ def slot_to_cmd(slot, update=False):
 
 class PrepareUploadError(Enum):
     # Defined here
-    CONNECTION_FAILED = 'Failed to open HTTPS connection'
-    NOT_FOUND = 'Upload request not recognized by server'
-    SERVICE_UNAVAILABLE = 'Service temporarily unavailable, please try again later'  # noqa: E501
+    CONNECTION_FAILED = 'Failed to open HTTPS connection.'
+    NOT_FOUND = 'Upload request not recognized by server.'
+    SERVICE_UNAVAILABLE = 'Service temporarily unavailable, please try again later.'  # noqa: E501
 
     # Defined in upload project
     PRIVATE_ID_INVALID_LENGTH = 'Private ID must be 12 characters long.'

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -164,10 +164,18 @@ class OtpController(object):
             resp_body = resp.read()
             try:
                 errors = json.loads(resp_body.decode('utf-8'))['errors']
-                return {'success': False, 'errors': errors}
+                return {
+                    'success': False,
+                    'status': resp.status,
+                    'errors': errors,
+                }
             except Exception as e:
                 logger.debug('YubiCloud key upload failed', exc_info=e)
-                return {'success': False, 'content': resp_body}
+                return {
+                    'success': False,
+                    'status': resp.status,
+                    'content': resp_body,
+                }
 
     def program_static(self, slot, password, append_cr=True,
                        keyboard_layout=KEYBOARD_LAYOUT.MODHEX):

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -75,6 +75,7 @@ class PrepareUploadError(Enum):
     # Defined here
     CONNECTION_FAILED = 'Failed to open HTTPS connection'
     NOT_FOUND = 'Upload request not recognized by server'
+    SERVICE_UNAVAILABLE = 'Service temporarily unavailable, please try again later'  # noqa: E501
 
     # Defined in upload project
     PRIVATE_ID_INVALID_LENGTH = 'Private ID must be 12 characters long.'
@@ -206,6 +207,10 @@ class OtpController(object):
             if resp.status == 404:
                 raise PrepareUploadFailed(
                     resp.status, resp_body, [PrepareUploadError.NOT_FOUND])
+            elif resp.status == 503:
+                raise PrepareUploadFailed(
+                    resp.status, resp_body,
+                    [PrepareUploadError.SERVICE_UNAVAILABLE])
             else:
                 try:
                     errors = json.loads(resp_body.decode('utf-8')).get('errors')

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -141,7 +141,7 @@ class OtpController(object):
         modhex_public_id = modhex_encode(public_id)
         data = {
             'aeskey': binascii.b2a_hex(key).decode('utf-8'),
-            'serial': str(serial),
+            'serial': serial,
             'prefix': modhex_public_id,
             'uid': binascii.b2a_hex(private_id).decode('utf-8'),
         }

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -140,11 +140,11 @@ class OtpController(object):
         modhex_public_id = modhex_encode(public_id)
         data = {
             'aeskey': binascii.b2a_hex(key).decode('utf-8'),
-            'serial': serial,
+            'serial': str(serial),
             'prefix': modhex_public_id,
             'uid': binascii.b2a_hex(private_id).decode('utf-8'),
         }
-        prepare_post = requests.post(UPLOAD_URL, data=data)
+        prepare_post = requests.post(UPLOAD_URL, json=data)
 
         if prepare_post.status_code == 200:
             url = prepare_post.json()['finish_url']

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -131,17 +131,11 @@ class OtpController(object):
         finally:
             ykpers.ykp_free_config(cfg)
 
-    def prepare_upload_key(self, key, public_id, private_id):
-        serial_ref = c_uint()
-        if ykpers.yk_get_serial(self._dev, 0, 0, byref(serial_ref)):
-            serial = serial_ref.value
-        else:
-            serial = 0
-
+    def prepare_upload_key(self, key, public_id, private_id, serial=None):
         modhex_public_id = modhex_encode(public_id)
         data = {
             'aes_key': b2a_hex(key).decode('utf-8'),
-            'serial': serial,
+            'serial': serial or 0,
             'public_id': modhex_public_id,
             'private_id': b2a_hex(private_id).decode('utf-8'),
         }

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -27,7 +27,6 @@
 
 from __future__ import absolute_import
 
-import binascii
 import http.client
 import json
 import logging
@@ -141,10 +140,10 @@ class OtpController(object):
 
         modhex_public_id = modhex_encode(public_id)
         data = {
-            'aes_key': binascii.b2a_hex(key).decode('utf-8'),
+            'aes_key': b2a_hex(key).decode('utf-8'),
             'serial': serial,
             'public_id': modhex_public_id,
-            'private_id': binascii.b2a_hex(private_id).decode('utf-8'),
+            'private_id': b2a_hex(private_id).decode('utf-8'),
         }
 
         httpconn = http.client.HTTPSConnection(UPLOAD_HOST, timeout=1)


### PR DESCRIPTION
This adds some integration with upload.yubico.com to the ykman CLI.

- If the `--upload` option is given to the `ykman otp yubiotp` command, the CLI will initiate a key upload and then open the prepared form in the user's browser.
- The key and private ID are sent in the POST body of a background HTTP request, and the server responds with a request ID that is then opened as a GET URL in the browser.
- If the POST request fails, nothing is written to the YubiKey.
- The POST request includes a `User-Agent` header identifying the ykman version.
- The key is not written to disk or exposed to browser history.
- The POST request is sent and processed in the library so the same logic can be reused in the GUI.

This code currently writes quite a lot of output in the CLI, perhaps we'll want to focus and trim that down a bit.