### PR TITLE
settings: add support for USE_NUMERIC_KEYPAD

### DIFF
--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -569,8 +569,11 @@ def hotp(ctx, slot, key, digits, counter, no_enter, force):
     '-p', '--pacing', type=click.Choice(['0', '20', '40', '60']),
     default='0', show_default=True, help='Throttle output speed by '
     'adding a delay (in ms) between characters emitted.')
+@click.option('--use-numeric-keypad', is_flag=True, show_default=True,
+        help='Use scancodes for numeric keypad when sending digits.'
+             ' Helps with some keyboard layouts. ')
 def settings(ctx, slot, new_access_code, delete_access_code, enter, pacing,
-             force):
+             use_numeric_keypad, force):
     """
     Update the settings for a slot.
 
@@ -605,7 +608,8 @@ def settings(ctx, slot, new_access_code, delete_access_code, enter, pacing,
         pacing = int(pacing)
 
     try:
-        controller.update_settings(slot, enter=enter, pacing=pacing)
+        controller.update_settings(
+            slot, enter=enter, pacing=pacing, use_numeric_keypad=use_numeric_keypad)
     except YkpersError as e:
         _failed_to_write_msg(ctx, e)
 

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -411,7 +411,9 @@ class OtpController(object):
 
         self.set_access_code(slot, None)
 
-    def update_settings(self, slot, enter=True, pacing=None):
+    def update_settings(
+            self, slot, enter=True, pacing=None,
+            use_numeric_keypad=False):
         cmd = slot_to_cmd(slot, update=True)
         cfg = self._create_cfg(cmd)
         if enter:
@@ -426,6 +428,8 @@ class OtpController(object):
             check(ykpers.ykp_set_cfgflag(cfg, 'PACING_10MS'))
             check(ykpers.ykp_set_cfgflag(cfg, 'PACING_20MS'))
 
+        if use_numeric_keypad:
+            check(ykpers.ykp_set_extflag(cfg, 'USE_NUMERIC_KEYPAD'))
         try:
             check(ykpers.yk_write_command(
                 self._dev, ykpers.ykp_core_config(cfg), cmd, self.access_code))


### PR DESCRIPTION
Add support for `USE_NUMERIC_KEYPAD` flag to better support HOTP credentials in combination with AZERTY keyboard layouts. 

To enable:
`$ ykman otp settings SLOT --use-numeric-keypad`