### PR TITLE
Add -e Initial time since the UNIX epoch from which to calculate the counter value.

### DIFF
--- a/ykman/cli/oath.py
+++ b/ykman/cli/oath.py
@@ -332,7 +332,9 @@ def list(ctx, show_hidden, oath_type, period):
 @click.argument('query', required=False, default='')
 @click.option('-s', '--single', is_flag=True, help='Ensure only a single '
               'match, and output only the code.')
-def code(ctx, show_hidden, query, single):
+@click.option('-e', '--epoch', type=click.INT, default=0, help='Initial time since the UNIX epoch from '
+              'which to calculate the counter value. Defaults to 0 (no offset).')
+def code(ctx, show_hidden, query, single, epoch):
     """
     Generate codes.
 
@@ -345,7 +347,7 @@ def code(ctx, show_hidden, query, single):
 
     controller = ctx.obj['controller']
     creds = [(cr, c)
-             for (cr, c) in controller.calculate_all()
+             for (cr, c) in controller.calculate_all(epoch=epoch)
              if show_hidden or not cr.is_hidden
              ]
 

--- a/ykman/oath.py
+++ b/ykman/oath.py
@@ -337,9 +337,11 @@ class OathController(object):
         data = Tlv(TAG.NAME, cred.key)
         self.send_apdu(INS.DELETE, 0, 0, data)
 
-    def calculate_all(self, timestamp=None):
+    def calculate_all(self, timestamp=None, epoch=0):
         if timestamp is None:
             timestamp = int(time.time())
+
+        timestamp -= epoch
 
         def _gen_all():
             valid_from = timestamp - (timestamp % 30)


### PR DESCRIPTION
Initial time since the UNIX epoch from which to calculate the counter value.
Defaults to 0 (no offset).

example:

```
ykman oath code -e 123456 -s hello
```
