### PR TITLE
Support NEO on newer Windows versions

### DIFF
--- a/ykman/device.py
+++ b/ykman/device.py
@@ -231,10 +231,10 @@ class YubiKey(object):
                 else:  # Assume base capabilities
                     logger.debug('CCID not available, guess capabilities')
                     usb_supported = _NEO_BASE_CAPABILITIES
-                    if TRANSPORT.has(self.mode.transports, TRANSPORT.FIDO) \
-                            or (version and version >= (3, 3, 0)):
-                        usb_supported |= APPLICATION.U2F
-
+                # NEO over 3.3.0 have U2F (which might be blocked by OS)
+                if TRANSPORT.has(self.mode.transports, TRANSPORT.FIDO) \
+                        or (version and version >= (3, 3, 0)):
+                    usb_supported |= APPLICATION.U2F
                 config._set(TAG.USB_SUPPORTED, usb_supported)
                 config._set(TAG.NFC_SUPPORTED, usb_supported)
                 config._set(TAG.NFC_ENABLED, usb_supported)

--- a/ykman/driver_ccid.py
+++ b/ykman/driver_ccid.py
@@ -219,6 +219,14 @@ class CCIDDriver(AbstractDriver):
                 logger.debug(
                     'Failed reading applet: aid: %s , capability: %s , %s',
                     aid, code, e)
+                # NEO over 3.3.0 have U2F, might fail
+                # because of access can be blocked
+                # on some operating systems.
+                if self.key_type == YUBIKEY.NEO and aid == AID.U2F:
+                    s = self.select(AID.OTP)
+                    v = tuple(c for c in six.iterbytes(s[:3]))
+                    if v >= (3, 3, 0):
+                        capa |= code
         return capa
 
     def send_apdu(self, cl, ins, p1, p2, data=b'', check=SW.OK):

--- a/ykman/driver_ccid.py
+++ b/ykman/driver_ccid.py
@@ -215,6 +215,10 @@ class CCIDDriver(AbstractDriver):
             except APDUError:
                 logger.debug(
                     'Missing applet: aid: %s , capability: %s', aid, code)
+            except CCIDError as e:
+                logger.debug(
+                    'Failed reading applet: aid: %s , capability: %s , %s',
+                    aid, code, e)
         return capa
 
     def send_apdu(self, cl, ins, p1, p2, data=b'', check=SW.OK):

--- a/ykman/driver_ccid.py
+++ b/ykman/driver_ccid.py
@@ -219,14 +219,6 @@ class CCIDDriver(AbstractDriver):
                 logger.debug(
                     'Failed reading applet: aid: %s , capability: %s , %s',
                     aid, code, e)
-                # NEO over 3.3.0 have U2F, might fail
-                # because of access can be blocked
-                # on some operating systems.
-                if self.key_type == YUBIKEY.NEO and aid == AID.U2F:
-                    s = self.select(AID.OTP)
-                    version = tuple(c for c in six.iterbytes(s[:3]))
-                    if version >= (3, 3, 0):
-                        capa |= code
         return capa
 
     def send_apdu(self, cl, ins, p1, p2, data=b'', check=SW.OK):

--- a/ykman/driver_ccid.py
+++ b/ykman/driver_ccid.py
@@ -224,8 +224,8 @@ class CCIDDriver(AbstractDriver):
                 # on some operating systems.
                 if self.key_type == YUBIKEY.NEO and aid == AID.U2F:
                     s = self.select(AID.OTP)
-                    v = tuple(c for c in six.iterbytes(s[:3]))
-                    if v >= (3, 3, 0):
+                    version = tuple(c for c in six.iterbytes(s[:3]))
+                    if version >= (3, 3, 0):
                         capa |= code
         return capa
 


### PR DESCRIPTION
- When probing capabilities on the NEO, the FIDO U2F applet is selected, which fails with access denied on latest Windows 10 (if not run as administrator). Leads to failures like this https://github.com/Yubico/yubioath-desktop/issues/368
- Catch error, log it.
- If the device is a NEO and version is over 3.3.0 report U2F as a supported capability. 