### PR TITLE
ykman list: list based on descriptors

### DIFF
--- a/ykman/cli/__main__.py
+++ b/ykman/cli/__main__.py
@@ -127,7 +127,7 @@ def _run_cmd_for_single(ctx, cmd, transports, reader=None):
         try:
             return descriptor.open_device(transports)
         except FailedOpeningDeviceException:
-            ctx.fail('Failed connecting to the YubiKey.')
+            ctx.fail('Failed connecting to {} [{}]'.format(descriptor.name, descriptor.mode))
     else:
         _disabled_transport(ctx, transports, cmd)
 
@@ -244,18 +244,7 @@ def list_keys(ctx, serials, readers):
     # List descriptors that failed to open.
     logger.debug('Failed to open all devices, listing based on descriptors')
     for desc in descriptors:
-        if desc.key_type == YUBIKEY.SKY:
-            if desc.version >= (5, 1, 0):
-                name = 'Security Key NFC'
-            elif desc.version <= (5, 0, 0):
-                name = 'FIDO U2F Security Key'
-            else:
-                name = desc.key_type.value
-        elif desc.key_type == YUBIKEY.YK4 and desc.version >= (5, 0, 0):
-            name = 'YubiKey 5'
-        else:
-            name = desc.key_type.value
-        click.echo('{} [{}]'.format(name, desc.mode))
+        click.echo('{} [{}]'.format(desc.name, desc.mode))
 
 COMMANDS = (list_keys, info, mode, otp, openpgp, oath, piv, fido, config)
 

--- a/ykman/descriptor.py
+++ b/ykman/descriptor.py
@@ -27,7 +27,7 @@
 
 from __future__ import absolute_import
 
-from .util import PID, TRANSPORT, Mode
+from .util import PID, TRANSPORT, Mode, YUBIKEY
 from .device import YubiKey
 from .driver_ccid import open_devices as open_ccid
 from .driver_fido import open_devices as open_fido
@@ -69,6 +69,20 @@ class Descriptor(object):
     @property
     def key_type(self):
         return self._key_type
+
+    @property
+    def name(self):
+        if self.key_type == YUBIKEY.SKY:
+            if self.version >= (5, 1, 0):
+                return'Security Key NFC'
+            elif self.version <= (5, 0, 0):
+                return 'FIDO U2F Security Key'
+            else:
+                return desc.key_type.value
+        elif self.key_type == YUBIKEY.YK4 and self.version >= (5, 0, 0):
+            return 'YubiKey 5'
+        else:
+            return self.key_type.value
 
     def open_device(self, transports=sum(TRANSPORT), serial=None, attempts=10):
         self._logger.debug('transports: 0x%x, self.mode.transports: 0x%x',

--- a/ykman/descriptor.py
+++ b/ykman/descriptor.py
@@ -72,7 +72,7 @@ class Descriptor(object):
 
     @property
     def name(self):
-        if self.key_type == YUBIKEY.SKY and self.version <= (5, 0, 0):
+        if self.key_type == YUBIKEY.SKY and self.version < (5, 0, 0):
             return 'FIDO U2F Security Key'
         elif self.key_type == YUBIKEY.YK4 and self.version >= (5, 0, 0):
             return 'YubiKey 5'

--- a/ykman/descriptor.py
+++ b/ykman/descriptor.py
@@ -72,13 +72,8 @@ class Descriptor(object):
 
     @property
     def name(self):
-        if self.key_type == YUBIKEY.SKY:
-            if self.version >= (5, 1, 0):
-                return'Security Key NFC'
-            elif self.version <= (5, 0, 0):
-                return 'FIDO U2F Security Key'
-            else:
-                return desc.key_type.value
+        if self.key_type == YUBIKEY.SKY and self.version <= (5, 0, 0):
+            return 'FIDO U2F Security Key'
         elif self.key_type == YUBIKEY.YK4 and self.version >= (5, 0, 0):
             return 'YubiKey 5'
         else:


### PR DESCRIPTION
- Add a `name` property on the descriptor object (uses PID and version to come up with a name)
- Simplify SKY specific code in list command
- If any device failed to open, list it based on the information available in the descriptor

Examples with FIDO only device on Win 10:
```
$ ykman.exe list
Security Key NFC [FIDO]

$ ykman.exe info
Error: Failed connecting to Security Key NFC [FIDO]
```
 