### PR TITLE
Fix broken tests

### DIFF
--- a/test/on_yubikey/cli_piv/test_key_management.py
+++ b/test/on_yubikey/cli_piv/test_key_management.py
@@ -107,7 +107,7 @@ class KeyManagement(PivTestCase):
             csr = x509.load_pem_x509_csr(output.encode(), default_backend())
             self.assertTrue(csr.is_signature_valid)
 
-    def test_import_correct_cert_succeeds_with_pin(self):
+    def test_import_verify_correct_cert_succeeds_with_pin(self):
         # Set up a key in the slot and create a certificate for it
         public_key_pem = ykman_cli(
             'piv', 'generate-key', '9a', '-a', 'ECCP256', '-m',
@@ -122,17 +122,20 @@ class KeyManagement(PivTestCase):
 
         with self.assertRaises(SystemExit):
             ykman_cli(
-                'piv', 'import-certificate', '9a', '/tmp/test-pub-key.pem',
+                'piv', 'import-certificate', '--verify',
+                '9a', '/tmp/test-pub-key.pem',
                 '-m', DEFAULT_MANAGEMENT_KEY)
 
         ykman_cli(
-            'piv', 'import-certificate', '9a', '/tmp/test-pub-key.pem',
+            'piv', 'import-certificate', '--verify',
+            '9a', '/tmp/test-pub-key.pem',
             '-m', DEFAULT_MANAGEMENT_KEY, '-P', DEFAULT_PIN)
         ykman_cli(
-            'piv', 'import-certificate', '9a', '/tmp/test-pub-key.pem',
+            'piv', 'import-certificate', '--verify',
+            '9a', '/tmp/test-pub-key.pem',
             '-m', DEFAULT_MANAGEMENT_KEY, input=DEFAULT_PIN)
 
-    def test_import_wrong_cert_fails(self):
+    def test_import_verify_wrong_cert_fails(self):
         # Set up a key in the slot and create a certificate for it
         public_key_pem = ykman_cli(
             'piv', 'generate-key', '9a', '-a', 'ECCP256', '-m',
@@ -153,10 +156,10 @@ class KeyManagement(PivTestCase):
 
         with self.assertRaises(SystemExit):
             ykman_cli(
-                'piv', 'import-certificate', '9a', '-',
+                'piv', 'import-certificate', '--verify', '9a', '-',
                 '-m', DEFAULT_MANAGEMENT_KEY, '-P', DEFAULT_PIN, input=cert_pem)
 
-    def test_import_wrong_cert_can_be_forced(self):
+    def test_import_no_verify_wrong_cert_succeeds(self):
         # Set up a key in the slot and create a certificate for it
         public_key_pem = ykman_cli(
             'piv', 'generate-key', '9a', '-a', 'ECCP256', '-m',
@@ -177,7 +180,7 @@ class KeyManagement(PivTestCase):
 
         with self.assertRaises(SystemExit):
             ykman_cli(
-                'piv', 'import-certificate', '9a', '-',
+                'piv', 'import-certificate', '--verify', '9a', '-',
                 '-m', DEFAULT_MANAGEMENT_KEY, '-P', DEFAULT_PIN, input=cert_pem)
 
         ykman_cli(

--- a/test/on_yubikey/test_cli_misc.py
+++ b/test/on_yubikey/test_cli_misc.py
@@ -13,7 +13,7 @@ class TestYkmanInfo(DestructiveYubikeyTestCase):
 
     @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
     def test_ykman_info_does_not_report_fips_for_non_fips_device(self):
-        info = ykman_cli('info --check-fips')
+        info = ykman_cli('info', '--check-fips')
         self.assertNotIn('FIPS', info)
 
     @unittest.skipIf(not is_fips(), 'YubiKey FIPS required.')


### PR DESCRIPTION
- Fix an incorrect invocation of `ykman info --check-fips` (one string `'info --check-fips'` instead of two (`'info'`, `'--check-fips'`)
- Update tests of `ykman piv import-certificate` to reflect that verification of certificate/key pairing is now opt-in instead of opt-out