### PR TITLE
Fix some broken tests

### DIFF
--- a/test/on_yubikey/cli_piv/test_generate_cert_and_csr.py
+++ b/test/on_yubikey/cli_piv/test_generate_cert_and_csr.py
@@ -4,7 +4,7 @@ from cryptography import x509
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec, rsa, padding
-from ..util import ykman_cli, is_fips
+from ..util import ykman_cli, is_fips, skip_roca
 from .util import (
     PivTestCase, DEFAULT_PIN, DEFAULT_MANAGEMENT_KEY,
     NON_DEFAULT_MANAGEMENT_KEY)
@@ -33,73 +33,103 @@ class NonDefaultMgmKey(PivTestCase):
                   '-m', DEFAULT_MANAGEMENT_KEY,
                   '-n', NON_DEFAULT_MANAGEMENT_KEY)
 
-    def _test_generate_self_signed(self, slot):
-        for algo in ('ECCP256', 'RSA1024'):
-            pubkey_output = ykman_cli(
-                'piv', 'generate-key', slot, '-a', algo, '-m',
-                NON_DEFAULT_MANAGEMENT_KEY, '-')
-            ykman_cli(
-                'piv', 'generate-certificate', slot, '-m',
-                NON_DEFAULT_MANAGEMENT_KEY,
-                '-s', 'subject-' + algo, '-P', DEFAULT_PIN,
-                '-', input=pubkey_output)
-            output = ykman_cli('piv', 'export-certificate', slot, '-')
-            cert = x509.load_pem_x509_certificate(output.encode(),
-                                                  default_backend())
-            _verify_cert(cert, cert.public_key())
-            fingerprint = b2a_hex(cert.fingerprint(hashes.SHA256())).decode(
-                'ascii')
+    def _test_generate_self_signed(self, slot, algo):
+        pubkey_output = ykman_cli(
+            'piv', 'generate-key', slot, '-a', algo, '-m',
+            NON_DEFAULT_MANAGEMENT_KEY, '-')
+        ykman_cli(
+            'piv', 'generate-certificate', slot, '-m',
+            NON_DEFAULT_MANAGEMENT_KEY,
+            '-s', 'subject-' + algo, '-P', DEFAULT_PIN,
+            '-', input=pubkey_output)
+        output = ykman_cli('piv', 'export-certificate', slot, '-')
+        cert = x509.load_pem_x509_certificate(output.encode(),
+                                              default_backend())
+        _verify_cert(cert, cert.public_key())
+        fingerprint = b2a_hex(cert.fingerprint(hashes.SHA256())).decode(
+            'ascii')
 
-            output = ykman_cli('piv', 'info')
-            self.assertIn('Fingerprint:\t' + fingerprint, output)
-
-    @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
-    def test_generate_self_signed_slot_9a(self):
-        self._test_generate_self_signed('9a')
+        output = ykman_cli('piv', 'info')
+        self.assertIn('Fingerprint:\t' + fingerprint, output)
 
     @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
-    def test_generate_self_signed_slot_9c(self):
-        self._test_generate_self_signed('9c')
+    @unittest.skipIf(*skip_roca)
+    def test_generate_self_signed_slot_9a_rsa1024(self):
+        self._test_generate_self_signed('9a', 'RSA1024')
+
+    def test_generate_self_signed_slot_9a_eccp256(self):
+        self._test_generate_self_signed('9a', 'ECCP256')
 
     @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
-    def test_generate_self_signed_slot_9d(self):
-        self._test_generate_self_signed('9d')
+    @unittest.skipIf(*skip_roca)
+    def test_generate_self_signed_slot_9c_rsa1024(self):
+        self._test_generate_self_signed('9c', 'RSA1024')
+
+    def test_generate_self_signed_slot_9c_eccp256(self):
+        self._test_generate_self_signed('9c', 'ECCP256')
 
     @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
-    def test_generate_self_signed_slot_9e(self):
-        self._test_generate_self_signed('9e')
+    @unittest.skipIf(*skip_roca)
+    def test_generate_self_signed_slot_9d_rsa1024(self):
+        self._test_generate_self_signed('9d', 'RSA1024')
 
-    def _test_generate_csr(self, slot):
-        for algo in ('ECCP256', 'RSA1024'):
-            subject_input = 'subject-' + algo
-            pubkey_output = ykman_cli(
-                'piv', 'generate-key', slot, '-a', algo,
-                '-m', NON_DEFAULT_MANAGEMENT_KEY, '-')
-            csr_output = ykman_cli(
-                'piv', 'generate-csr', slot, '-P', DEFAULT_PIN,
-                '-', '-', '-s', subject_input, input=pubkey_output)
-            csr = x509.load_pem_x509_csr(csr_output.encode('utf-8'),
-                                         default_backend())
-            subject_output = csr.subject.get_attributes_for_oid(
-                x509.NameOID.COMMON_NAME)[0].value
-
-            self.assertEqual(subject_input, subject_output)
+    def test_generate_self_signed_slot_9d_eccp256(self):
+        self._test_generate_self_signed('9d', 'ECCP256')
 
     @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
-    def test_generate_csr_slot_9a(self):
-        self._test_generate_csr('9a')
+    @unittest.skipIf(*skip_roca)
+    def test_generate_self_signed_slot_9e_rsa1024(self):
+        self._test_generate_self_signed('9e', 'RSA1024')
+
+    def test_generate_self_signed_slot_9e_eccp256(self):
+        self._test_generate_self_signed('9e', 'ECCP256')
+
+    def _test_generate_csr(self, slot, algo):
+        subject_input = 'subject-' + algo
+        pubkey_output = ykman_cli(
+            'piv', 'generate-key', slot, '-a', algo,
+            '-m', NON_DEFAULT_MANAGEMENT_KEY, '-')
+        csr_output = ykman_cli(
+            'piv', 'generate-csr', slot, '-P', DEFAULT_PIN,
+            '-', '-', '-s', subject_input, input=pubkey_output)
+        csr = x509.load_pem_x509_csr(csr_output.encode('utf-8'),
+                                     default_backend())
+        subject_output = csr.subject.get_attributes_for_oid(
+            x509.NameOID.COMMON_NAME)[0].value
+
+        self.assertEqual(subject_input, subject_output)
 
     @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
-    def test_generate_csr_slot_9c(self):
-        self._test_generate_csr('9c')
+    @unittest.skipIf(*skip_roca)
+    def test_generate_csr_slot_9a_rsa1024(self):
+        self._test_generate_csr('9a', 'RSA1024')
+
+    def test_generate_csr_slot_9a_eccp256(self):
+        self._test_generate_csr('9a', 'ECCP256')
 
     @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
-    def test_generate_csr_slot_9d(self):
-        self._test_generate_csr('9d')
+    @unittest.skipIf(*skip_roca)
+    def test_generate_csr_slot_9c_rsa1024(self):
+        self._test_generate_csr('9c', 'RSA1024')
+
+    def test_generate_csr_slot_9c_eccp256(self):
+        self._test_generate_csr('9c', 'ECCP256')
 
     @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
-    def test_generate_csr_slot_9e(self):
-        self._test_generate_csr('9e')
+    @unittest.skipIf(*skip_roca)
+    def test_generate_csr_slot_9d_rsa1024(self):
+        self._test_generate_csr('9d', 'RSA1024')
+
+    def test_generate_csr_slot_9d_eccp256(self):
+        self._test_generate_csr('9d', 'ECCP256')
+
+    @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
+    @unittest.skipIf(*skip_roca)
+    def test_generate_csr_slot_9e_rsa1024(self):
+        self._test_generate_csr('9e', 'RSA1024')
+
+    def test_generate_csr_slot_9e_eccp256(self):
+        self._test_generate_csr('9e', 'ECCP256')
 
 
 class ProtectedMgmKey(PivTestCase):
@@ -110,70 +140,99 @@ class ProtectedMgmKey(PivTestCase):
         ykman_cli('piv', 'change-management-key', '-p', '-P', DEFAULT_PIN,
                   '-m', DEFAULT_MANAGEMENT_KEY)
 
-    def _test_generate_self_signed(self, slot):
-        for algo in ('ECCP256', 'RSA1024'):
-            pubkey_output = ykman_cli(
-                'piv', 'generate-key', slot, '-a', algo, '-P', DEFAULT_PIN,
-                '-')
-            ykman_cli(
-                'piv', 'generate-certificate', slot, '-P', DEFAULT_PIN,
-                '-s', 'subject-' + algo,
-                '-', input=pubkey_output)
-            output = ykman_cli('piv', 'export-certificate', slot, '-')
-            cert = x509.load_pem_x509_certificate(output.encode(),
-                                                  default_backend())
-            _verify_cert(cert, cert.public_key())
-            fingerprint = b2a_hex(cert.fingerprint(hashes.SHA256())).decode(
-                'ascii')
+    def _test_generate_self_signed(self, slot, algo):
+        pubkey_output = ykman_cli(
+            'piv', 'generate-key', slot, '-a', algo, '-P', DEFAULT_PIN,
+            '-')
+        ykman_cli(
+            'piv', 'generate-certificate', slot, '-P', DEFAULT_PIN,
+            '-s', 'subject-' + algo,
+            '-', input=pubkey_output)
+        output = ykman_cli('piv', 'export-certificate', slot, '-')
+        cert = x509.load_pem_x509_certificate(output.encode(),
+                                              default_backend())
+        _verify_cert(cert, cert.public_key())
+        fingerprint = b2a_hex(cert.fingerprint(hashes.SHA256())).decode(
+            'ascii')
 
-            output = ykman_cli('piv', 'info')
-            self.assertIn('Fingerprint:\t' + fingerprint, output)
-
-    @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
-    def test_generate_self_signed_slot_9a(self):
-        self._test_generate_self_signed('9a')
+        output = ykman_cli('piv', 'info')
+        self.assertIn('Fingerprint:\t' + fingerprint, output)
 
     @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
-    def test_generate_self_signed_slot_9c(self):
-        self._test_generate_self_signed('9c')
+    @unittest.skipIf(*skip_roca)
+    def test_generate_self_signed_slot_9a_rsa1024(self):
+        self._test_generate_self_signed('9a', 'RSA1024')
+
+    def test_generate_self_signed_slot_9a_eccp256(self):
+        self._test_generate_self_signed('9a', 'ECCP256')
 
     @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
-    def test_generate_self_signed_slot_9d(self):
-        self._test_generate_self_signed('9d')
+    @unittest.skipIf(*skip_roca)
+    def test_generate_self_signed_slot_9c_rsa1024(self):
+        self._test_generate_self_signed('9c', 'RSA1024')
+
+    def test_generate_self_signed_slot_9c_eccp256(self):
+        self._test_generate_self_signed('9c', 'ECCP256')
 
     @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
-    def test_generate_self_signed_slot_9e(self):
-        self._test_generate_self_signed('9e')
+    @unittest.skipIf(*skip_roca)
+    def test_generate_self_signed_slot_9d_rsa1024(self):
+        self._test_generate_self_signed('9d', 'RSA1024')
+
+    def test_generate_self_signed_slot_9d_eccp256(self):
+        self._test_generate_self_signed('9d', 'ECCP256')
 
     @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
-    def _test_generate_csr(self, slot):
-        for algo in ('ECCP256', 'RSA1024'):
-            subject_input = 'subject-' + algo
-            pubkey_output = ykman_cli(
-                'piv', 'generate-key', slot, '-a', algo, '-P', DEFAULT_PIN,
-                '-')
-            csr_output = ykman_cli(
-                'piv', 'generate-csr', slot, '-P', DEFAULT_PIN,
-                '-', '-', '-s', subject_input, input=pubkey_output)
-            csr = x509.load_pem_x509_csr(csr_output.encode('utf-8'),
-                                         default_backend())
-            subject_output = csr.subject.get_attributes_for_oid(
-                x509.NameOID.COMMON_NAME)[0].value
+    @unittest.skipIf(*skip_roca)
+    def test_generate_self_signed_slot_9e_rsa1024(self):
+        self._test_generate_self_signed('9e', 'RSA1024')
 
-            self.assertEqual(subject_input, subject_output)
+    def test_generate_self_signed_slot_9e_eccp256(self):
+        self._test_generate_self_signed('9e', 'ECCP256')
 
-    @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
-    def test_generate_csr_slot_9a(self):
-        self._test_generate_csr('9a')
+    def _test_generate_csr(self, slot, algo):
+        subject_input = 'subject-' + algo
+        pubkey_output = ykman_cli(
+            'piv', 'generate-key', slot, '-a', algo, '-P', DEFAULT_PIN,
+            '-')
+        csr_output = ykman_cli(
+            'piv', 'generate-csr', slot, '-P', DEFAULT_PIN,
+            '-', '-', '-s', subject_input, input=pubkey_output)
+        csr = x509.load_pem_x509_csr(csr_output.encode('utf-8'),
+                                     default_backend())
+        subject_output = csr.subject.get_attributes_for_oid(
+            x509.NameOID.COMMON_NAME)[0].value
 
-    @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
-    def test_generate_csr_slot_9c(self):
-        self._test_generate_csr('9c')
+        self.assertEqual(subject_input, subject_output)
 
     @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
-    def test_generate_csr_slot_9d(self):
-        self._test_generate_csr('9d')
+    @unittest.skipIf(*skip_roca)
+    def test_generate_csr_slot_9a_rsa1024(self):
+        self._test_generate_csr('9a', 'RSA1024')
+
+    def test_generate_csr_slot_9a_eccp256(self):
+        self._test_generate_csr('9a', 'ECCP256')
 
     @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
-    def test_generate_csr_slot_9e(self):
-        self._test_generate_csr('9e')
+    @unittest.skipIf(*skip_roca)
+    def test_generate_csr_slot_9c_rsa1024(self):
+        self._test_generate_csr('9c', 'RSA1024')
+
+    def test_generate_csr_slot_9c_eccp256(self):
+        self._test_generate_csr('9c', 'ECCP256')
+
+    @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
+    @unittest.skipIf(*skip_roca)
+    def test_generate_csr_slot_9d_rsa1024(self):
+        self._test_generate_csr('9d', 'RSA1024')
+
+    def test_generate_csr_slot_9d_eccp256(self):
+        self._test_generate_csr('9d', 'ECCP256')
+
+    @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
+    @unittest.skipIf(*skip_roca)
+    def test_generate_csr_slot_9e_rsa1024(self):
+        self._test_generate_csr('9e', 'RSA1024')
+
+    def test_generate_csr_slot_9e_eccp256(self):
+        self._test_generate_csr('9e', 'ECCP256')

--- a/test/on_yubikey/test_cli_config.py
+++ b/test/on_yubikey/test_cli_config.py
@@ -1,3 +1,4 @@
+import time
 import unittest
 from .util import (DestructiveYubikeyTestCase, ykman_cli, can_write_config)
 
@@ -86,6 +87,9 @@ class TestConfigUSB(DestructiveYubikeyTestCase):
         self.assertNotIn('OATH', output)
         self.assertNotIn('PIV', output)
         self.assertNotIn('OpenPGP', output)
+
+        # Prevent communication errors in other tests
+        time.sleep(1)
 
 
 @unittest.skipIf(not can_write_config(), 'Device can not write config')

--- a/test/on_yubikey/test_cli_oath.py
+++ b/test/on_yubikey/test_cli_oath.py
@@ -30,8 +30,7 @@ PASSWORD = 'aaaa'
 @unittest.skipIf(*missing_mode(TRANSPORT.CCID))
 class TestOATH(DestructiveYubikeyTestCase):
 
-    @classmethod
-    def setUpClass(cls):
+    def setUp(cls):
         ykman_cli('oath', 'reset', '-f')
 
     def test_oath_info(self):

--- a/test/on_yubikey/test_cli_openpgp.py
+++ b/test/on_yubikey/test_cli_openpgp.py
@@ -6,6 +6,9 @@ from .util import (DestructiveYubikeyTestCase, missing_mode, ykman_cli)
 @unittest.skipIf(*missing_mode(TRANSPORT.CCID))
 class TestOpenPGP(DestructiveYubikeyTestCase):
 
+    def setUp(self):
+        ykman_cli('openpgp', 'reset', '-f')
+
     def test_openpgp_info(self):
         output = ykman_cli('openpgp', 'info')
         self.assertIn('OpenPGP version:', output)

--- a/test/on_yubikey/test_fips_u2f_commands.py
+++ b/test/on_yubikey/test_fips_u2f_commands.py
@@ -16,95 +16,92 @@ P2 = 0
 class TestFipsU2fCommands(DestructiveYubikeyTestCase):
 
     def test_echo_command(self):
-        dev = open_device(transports=TRANSPORT.FIDO)
+        with open_device(transports=TRANSPORT.FIDO) as dev:
+            res = dev.driver._dev.call(
+                CTAPHID.MSG,
+                struct.pack(
+                    '>HBBBH6s',
+                    FIPS_U2F_CMD.ECHO, P1, P2, 0, 6, b'012345'
+                ))
 
-        res = dev.driver._dev.call(
-            CTAPHID.MSG,
-            struct.pack(
-              '>HBBBH6s',
-              FIPS_U2F_CMD.ECHO, P1, P2, 0, 6, b'012345'
-            ))
-
-        self.assertEqual(res, b'012345\x90\x00')
+            self.assertEqual(res, b'012345\x90\x00')
 
     def test_pin_commands(self):
         # Assumes PIN is 012345 or not set at beginning of test
         # Sets PIN to 012345
 
-        dev = open_device(transports=TRANSPORT.FIDO)
-
-        verify_res1 = dev.driver._dev.call(
-            CTAPHID.MSG,
-            struct.pack(
-              '>HBBBH6s',
-              FIPS_U2F_CMD.VERIFY_PIN, P1, P2, 0, 6, b'012345'
-            ))
-
-        if verify_res1 == b'\x63\xc0':
-            self.skipTest('PIN set to something other than 012345')
-
-        if verify_res1 == b'\x69\x83':
-            self.skipTest('PIN blocked')
-
-        if verify_res1 == b'\x90\x00':
-            res = dev.driver._dev.call(
+        with open_device(transports=TRANSPORT.FIDO) as dev:
+            verify_res1 = dev.driver._dev.call(
                 CTAPHID.MSG,
                 struct.pack(
-                  '>HBBBHB6s6s',
-                  FIPS_U2F_CMD.SET_PIN, P1, P2, 0, 13, 6, b'012345', b'012345'
+                    '>HBBBH6s',
+                    FIPS_U2F_CMD.VERIFY_PIN, P1, P2, 0, 6, b'012345'
                 ))
-        else:
-            res = dev.driver._dev.call(
+
+            if verify_res1 == b'\x63\xc0':
+                self.skipTest('PIN set to something other than 012345')
+
+            if verify_res1 == b'\x69\x83':
+                self.skipTest('PIN blocked')
+
+            if verify_res1 == b'\x90\x00':
+                res = dev.driver._dev.call(
+                    CTAPHID.MSG,
+                    struct.pack(
+                        '>HBBBHB6s6s',
+                        FIPS_U2F_CMD.SET_PIN, P1, P2,
+                        0, 13, 6, b'012345', b'012345'
+                    ))
+            else:
+                res = dev.driver._dev.call(
+                    CTAPHID.MSG,
+                    struct.pack(
+                        '>HBBBHB6s',
+                        FIPS_U2F_CMD.SET_PIN, P1, P2, 0, 7, 6, b'012345'
+                    ))
+
+            verify_res2 = dev.driver._dev.call(
                 CTAPHID.MSG,
                 struct.pack(
-                  '>HBBBHB6s',
-                  FIPS_U2F_CMD.SET_PIN, P1, P2, 0, 7, 6, b'012345'
+                    '>HBBBH6s',
+                    FIPS_U2F_CMD.VERIFY_PIN, P1, P2, 0, 6, b'543210'
                 ))
 
-        verify_res2 = dev.driver._dev.call(
-            CTAPHID.MSG,
-            struct.pack(
-              '>HBBBH6s',
-              FIPS_U2F_CMD.VERIFY_PIN, P1, P2, 0, 6, b'543210'
-            ))
+            verify_res3 = dev.driver._dev.call(
+                CTAPHID.MSG,
+                struct.pack(
+                    '>HBBBH6s',
+                    FIPS_U2F_CMD.VERIFY_PIN, P1, P2, 0, 6, b'012345'
+                ))
 
-        verify_res3 = dev.driver._dev.call(
-            CTAPHID.MSG,
-            struct.pack(
-              '>HBBBH6s',
-              FIPS_U2F_CMD.VERIFY_PIN, P1, P2, 0, 6, b'012345'
-            ))
-
-        self.assertIn(verify_res1, [b'\x90\x00', b'\x69\x86'])  # OK / not set
-        self.assertEqual(res,         b'\x90\x00')  # Success
-        self.assertEqual(verify_res2, b'\x63\xc0')  # Incorrect PIN
-        self.assertEqual(verify_res3, b'\x90\x00')  # Success
+            self.assertIn(verify_res1, [b'\x90\x00', b'\x69\x86'])  # OK/not set
+            self.assertEqual(res,         b'\x90\x00')  # Success
+            self.assertEqual(verify_res2, b'\x63\xc0')  # Incorrect PIN
+            self.assertEqual(verify_res3, b'\x90\x00')  # Success
 
     def test_reset_command(self):
-        dev = open_device(transports=TRANSPORT.FIDO)
+        with open_device(transports=TRANSPORT.FIDO) as dev:
+            res = dev.driver._dev.call(
+                CTAPHID.MSG,
+                struct.pack(
+                    '>HBB',
+                    FIPS_U2F_CMD.RESET, P1, P2
+                ))
 
-        res = dev.driver._dev.call(
-            CTAPHID.MSG,
-            struct.pack(
-              '>HBB',
-              FIPS_U2F_CMD.RESET, P1, P2
-            ))
-
-        # 0x6985: Touch required
-        # 0x6986: Power cycle required
-        # 0x9000: Success
-        self.assertIn(res, [b'\x69\x85', b'\x69\x86', b'\x90\x00'])
+            # 0x6985: Touch required
+            # 0x6986: Power cycle required
+            # 0x9000: Success
+            self.assertIn(res, [b'\x69\x85', b'\x69\x86', b'\x90\x00'])
 
     def test_verify_fips_mode_command(self):
-        dev = open_device(transports=TRANSPORT.FIDO)
+        with open_device(transports=TRANSPORT.FIDO) as dev:
+            res = dev.driver._dev.call(
+                CTAPHID.MSG,
+                struct.pack(
+                    '>HBB',
+                    FIPS_U2F_CMD.VERIFY_FIPS_MODE, P1, P2
+                ))
 
-        res = dev.driver._dev.call(
-            CTAPHID.MSG,
-            struct.pack(
-              '>HBB',
-              FIPS_U2F_CMD.VERIFY_FIPS_MODE, P1, P2
-            ))
-
-        # 0x6a81: Function not supported (PIN not set - not FIPS Approved Mode)
-        # 0x9000: Success (PIN set - FIPS Approved Mode)
-        self.assertIn(res, [b'\x6a\x81', b'\x90\x00'])
+            # 0x6a81: Function not supported (PIN not set - not FIPS Mode)
+            # 0x9000: Success (PIN set - FIPS Approved Mode)
+            self.assertIn(res, [b'\x6a\x81', b'\x90\x00'])

--- a/test/on_yubikey/test_piv.py
+++ b/test/on_yubikey/test_piv.py
@@ -13,7 +13,8 @@ from ykman.piv import (
     AuthenticationBlocked, AuthenticationFailed, WrongPuk, KeypairMismatch)
 from ykman.util import TRANSPORT, parse_certificates, parse_private_key
 from .util import (
-    DestructiveYubikeyTestCase, missing_mode, open_device, get_version, is_fips)
+    DestructiveYubikeyTestCase, missing_mode, open_device, get_version,
+    is_fips, skip_roca)
 from ..util import open_file
 
 
@@ -214,9 +215,11 @@ class KeyManagement(PivTestCase):
                                                verify=True)
 
     @unittest.skipIf(is_fips(), 'Not applicable to YubiKey FIPS.')
+    @unittest.skipIf(*skip_roca)
     def test_import_certificate_verifies_key_pairing_rsa1024(self):
         self._test_import_key_pairing(ALGO.RSA1024, ALGO.ECCP256)
 
+    @unittest.skipIf(*skip_roca)
     def test_import_certificate_verifies_key_pairing_rsa2048(self):
         self._test_import_key_pairing(ALGO.RSA2048, ALGO.ECCP256)
 

--- a/test/test_external_libs.py
+++ b/test/test_external_libs.py
@@ -1,11 +1,7 @@
 import unittest
-import os
 from test.util import ykman_cli
 
 
-@unittest.skipIf(
-    os.environ.get('DESTRUCTIVE_TEST_YUBIKEY_SERIAL') is None,
-    'DESTRUCTIVE_TEST_YUBIKEY_SERIAL == None')
 class TestExternalLibraries(unittest.TestCase):
 
     def test_ykman_version(self):


### PR DESCRIPTION
- `TestExternalLibraries` does not need a YubiKey
- Some tests attempted RSA key generation on ROCA vulnerable devices
- OATH and/or OpenPGP tests sometimes crashed for no apparent reason, seems to be related to `test_mode_command` running just before them.