### PR TITLE
usb: load backend every time

### DIFF
--- a/ykman/native/pyusb.py
+++ b/ykman/native/pyusb.py
@@ -70,13 +70,8 @@ def _load_usb_backend():
             return backend
 
 
-_usb_backend = None
-
-
 def get_usb_backend():
-    global _usb_backend
-    _usb_backend = _usb_backend or _load_usb_backend()
-    return _usb_backend
+    return _load_usb_backend()
 
 
 class LibUsb1Version(ctypes.Structure):


### PR DESCRIPTION
On macOS, sometimes `usb.core.find(True, idVendor=0x1050, beckend=get_usb_backend)` (called in `ykman.desctiptor._gen_descriptors`) returned an incorrect list of devices, where a device that had been removed was still present. This change fixes that.