### PR TITLE
Remove unneeded re-export of load_library

### DIFF
--- a/ykman/native/util.py
+++ b/ykman/native/util.py
@@ -29,8 +29,6 @@ from .libloader import load_library
 import os
 import sys
 
-__all__ = ['load_library', 'use_library', 'CLibrary']
-
 
 def use_library(libname, version=None, extra_paths=[]):
     lib = load_library(libname, version, extra_paths)


### PR DESCRIPTION
This fixes an [LGTM alert](https://lgtm.com/projects/g/Yubico/yubikey-manager/snapshot/f73dda2b16d50f5186b8fa4ed4ee90d5ce7d3743/files/ykman/native/util.py#x12957e531cc49dee:1).