### PR TITLE
setup.py: Correct dependency on fido2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ import os
 from setuptools import setup
 
 install_requires = [
-    'six', 'pyscard', 'pyusb', 'click', 'cryptography', 'pyopenssl', 'fido2'
+    'six', 'pyscard', 'pyusb', 'click', 'cryptography', 'pyopenssl', 'fido2 >= 0.7'
 ]
 tests_require = []
 if sys.version_info < (3, 3):


### PR DESCRIPTION
`yubikey-manager` depends on APIs introduced in `fido2` v0.7.0.
If `fido2` follows semantic versioning conventions, this ought to be `fido2 ~= 0.7.0`.

I ran into this issue while packaging `ykman` v3.0.0.