### PR TITLE
Improve user feedback in opgp set-touch

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,7 @@
+* Version 3.1.1 (unreleased)
+ ** OpenPGP: set-touch now performs compatibility checks before prompting for PIN
+ ** OpenPGP: Improved error messages in set-touch
+
 * Version 3.1.0 (released 2019-08-20)
  ** Add support for YubiKey 5Ci
  ** OpenPGP: the info command now prints OpenPGP specification version as well

--- a/ykman/cli/opgp.py
+++ b/ykman/cli/opgp.py
@@ -166,13 +166,13 @@ def set_touch(ctx, key, policy, admin_pin, force):
     """
     controller = ctx.obj['controller']
 
-    if admin_pin is None:
-        admin_pin = click.prompt('Enter admin PIN', hide_input=True, err=True)
-
     policy_name = policy.name.lower().replace('_', '-')
 
     if policy not in controller.supported_touch_policies:
         ctx.fail('Touch policy {} not supported.'.format(policy_name))
+
+    if admin_pin is None:
+        admin_pin = click.prompt('Enter admin PIN', hide_input=True, err=True)
 
     if force or click.confirm(
         'Set touch policy of {} key to {}?'.format(

--- a/ykman/cli/opgp.py
+++ b/ykman/cli/opgp.py
@@ -172,6 +172,9 @@ def set_touch(ctx, key, policy, admin_pin, force):
         ctx.fail('Touch policy {} not supported by this YubiKey.'
                  .format(policy_name))
 
+    if key == KEY_SLOT.ATT and not controller.supports_attestation:
+        ctx.fail('Attestation is not supported by this YubiKey.')
+
     if admin_pin is None:
         admin_pin = click.prompt('Enter admin PIN', hide_input=True, err=True)
 

--- a/ykman/cli/opgp.py
+++ b/ykman/cli/opgp.py
@@ -169,7 +169,8 @@ def set_touch(ctx, key, policy, admin_pin, force):
     policy_name = policy.name.lower().replace('_', '-')
 
     if policy not in controller.supported_touch_policies:
-        ctx.fail('Touch policy {} not supported.'.format(policy_name))
+        ctx.fail('Touch policy {} not supported by this YubiKey.'
+                 .format(policy_name))
 
     if admin_pin is None:
         admin_pin = click.prompt('Enter admin PIN', hide_input=True, err=True)


### PR DESCRIPTION
- Clarify "touch policy not supported" message to say the policy is not supported by the user's particular YubiKey
- Fail faster if `ykman openpgp set-touch att ...` when YubiKey does not support attestation
- Prompt for admin PIN only after the checks are done