### PR TITLE
Fix crash when YubiOTP upload fails

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,7 @@
 * Version 3.1.1 (unreleased)
  ** OpenPGP: set-touch now performs compatibility checks before prompting for PIN
  ** OpenPGP: Improved error messages in set-touch
+ ** Bug fix: Fixed crash in OtpController.prepare_upload_key() error parsing
 
 * Version 3.1.0 (released 2019-08-20)
  ** Add support for YubiKey 5Ci

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -104,7 +104,7 @@ class PrepareUploadFailed(Exception):
         self.status = status
         self.content = content
         self.errors = [
-            e if e in PrepareUploadError else PrepareUploadError[e]
+            e if isinstance(e, PrepareUploadError) else PrepareUploadError[e]
             for e in error_ids]
 
     def messages(self):

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -88,9 +88,9 @@ class PrepareUploadError(Enum):
     PUBLIC_ID_UNDEFINED = 'Public ID is required.'
     SECRET_KEY_INVALID_LENGTH = 'Secret key must be 32 character long.'
     SECRET_KEY_NOT_HEX = 'Secret key must consist only of hex characters (0-9A-F).'  # noqa: E501
-    SECRET_KEY_UNDEFINED = 'AES key is required.'
+    SECRET_KEY_UNDEFINED = 'Secret key is required.'
     SERIAL_NOT_INT = 'Serial number must be an integer.'
-    SERIAL_TOO_LONG = 'Serial number too long.'
+    SERIAL_TOO_LONG = 'Serial number is too long.'
 
     def message(self):
         return self.value


### PR DESCRIPTION
Before:

```
$ ykman otp yubiotp 1 -SgG --upload
Using YubiKey serial as public ID: vvccccjffvkj
Using a randomly generated private ID: 36c941002411
Using a randomly generated secret key: bd86a981ae88490310d064dd6a0328b1
Traceback (most recent call last):
  File "/home/emlun/dev/yubikey-manager/.python-venv/bin/ykman", line 11, in <module>
    load_entry_point('yubikey-manager', 'console_scripts', 'ykman')()
  File "/home/emlun/dev/yubikey-manager/ykman/cli/__main__.py", line 268, in main
    cli(obj={})
  File "/home/emlun/dev/yubikey-manager/.python-venv/lib/python3.8/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/home/emlun/dev/yubikey-manager/.python-venv/lib/python3.8/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/home/emlun/dev/yubikey-manager/.python-venv/lib/python3.8/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/emlun/dev/yubikey-manager/.python-venv/lib/python3.8/site-packages/click/core.py", line 1137, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/home/emlun/dev/yubikey-manager/.python-venv/lib/python3.8/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/home/emlun/dev/yubikey-manager/.python-venv/lib/python3.8/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/home/emlun/dev/yubikey-manager/.python-venv/lib/python3.8/site-packages/click/decorators.py", line 17, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/emlun/dev/yubikey-manager/ykman/cli/otp.py", line 330, in yubiotp
    upload_url = controller.prepare_upload_key(
  File "/home/emlun/dev/yubikey-manager/ykman/otp.py", line 267, in prepare_upload_key
    raise PrepareUploadFailed(resp.status, resp_body, errors)
  File "/home/emlun/dev/yubikey-manager/ykman/otp.py", line 106, in __init__
    self.errors = [
  File "/home/emlun/dev/yubikey-manager/ykman/otp.py", line 107, in <listcomp>
    e if e in PrepareUploadError else PrepareUploadError[e]
  File "/usr/lib/python3.8/enum.py", line 310, in __contains__
    raise TypeError(
TypeError: unsupported operand type(s) for 'in': 'str' and 'EnumMeta'
```

After:

```
$ ykman otp yubiotp 1 -SgG --upload
Using YubiKey serial as public ID: vvccccjffvkj
Using a randomly generated private ID: 551f1525266a
Using a randomly generated secret key: 01a596f29f968fb61ed0fd0013aeb3ba
Usage: ykman otp yubiotp [OPTIONS] [1|2]
Try "ykman otp yubiotp -h" for help.

Error: Upload to YubiCloud failed.
Public ID is already in use.
```