### PR TITLE
Fix integration tests

### DIFF
--- a/test/on_yubikey/framework/__init__.py
+++ b/test/on_yubikey/framework/__init__.py
@@ -25,7 +25,7 @@ if _test_serials is not None:
     _test_serials = set(int(s) for s in _test_serials.split(','))
 
     for dev in list_devices():
-        print('{:%.3f} {}'.format(time.time() - start_time, dev))
+        print('{:.3f} {}'.format(time.time() - start_time, dev))
         _serials_present.add(dev.serial)
         _versions[dev.serial] = dev.version
         dev.close()

--- a/test/on_yubikey/test_opgp.py
+++ b/test/on_yubikey/test_opgp.py
@@ -120,3 +120,5 @@ def additional_tests(open_device):
             priv = x25519.X25519PrivateKey.generate()
             self.controller.verify_admin(DEFAULT_ADMIN_PIN)
             self.controller.import_key(KEY_SLOT.ENC, priv)
+
+    return [OpgpTestCase, KeyManagement]


### PR DESCRIPTION
This fixes 2 issues:

```
$ DESTRUCTIVE_TEST_YUBIKEY_SERIALS=7800014 python setup.py test
running test
running egg_info
writing yubikey_manager.egg-info/PKG-INFO
writing dependency_links to yubikey_manager.egg-info/dependency_links.txt
writing entry points to yubikey_manager.egg-info/entry_points.txt
writing requirements to yubikey_manager.egg-info/requires.txt
writing top-level names to yubikey_manager.egg-info/top_level.txt
reading manifest file 'yubikey_manager.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching 'ChangeLog'
warning: no files found matching 'resources/*'
warning: manifest_maker: MANIFEST.in, line 10: 'recursive-exclude' expects <dir> <pattern1> <pattern2> ...

writing manifest file 'yubikey_manager.egg-info/SOURCES.txt'
running build_ext
Initiating device discovery...
Traceback (most recent call last):
  File "setup.py", line 49, in <module>
    setup(
  File "/home/emlun/dev/yubikey-manager/.python-venv/lib/python3.8/site-packages/setuptools/__init__.py", line 145, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python3.8/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib/python3.8/distutils/dist.py", line 966, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3.8/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/home/emlun/dev/yubikey-manager/.python-venv/lib/python3.8/site-packages/setuptools/command/test.py", line 229, in run
    self.run_tests()
  File "/home/emlun/dev/yubikey-manager/.python-venv/lib/python3.8/site-packages/setuptools/command/test.py", line 247, in run_tests
    test = unittest.main(
  File "/usr/lib/python3.8/unittest/main.py", line 100, in __init__
    self.parseArgs(argv)
  File "/usr/lib/python3.8/unittest/main.py", line 147, in parseArgs
    self.createTests()
  File "/usr/lib/python3.8/unittest/main.py", line 158, in createTests
    self.test = self.testLoader.loadTestsFromNames(self.testNames,
  File "/usr/lib/python3.8/unittest/loader.py", line 220, in loadTestsFromNames
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/usr/lib/python3.8/unittest/loader.py", line 220, in <listcomp>
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/usr/lib/python3.8/unittest/loader.py", line 191, in loadTestsFromName
    return self.loadTestsFromModule(obj)
  File "/home/emlun/dev/yubikey-manager/.python-venv/lib/python3.8/site-packages/setuptools/command/test.py", line 55, in loadTestsFromModule
    tests.append(self.loadTestsFromName(submodule))
  File "/usr/lib/python3.8/unittest/loader.py", line 191, in loadTestsFromName
    return self.loadTestsFromModule(obj)
  File "/home/emlun/dev/yubikey-manager/.python-venv/lib/python3.8/site-packages/setuptools/command/test.py", line 55, in loadTestsFromModule
    tests.append(self.loadTestsFromName(submodule))
  File "/usr/lib/python3.8/unittest/loader.py", line 191, in loadTestsFromName
    return self.loadTestsFromModule(obj)
  File "/home/emlun/dev/yubikey-manager/.python-venv/lib/python3.8/site-packages/setuptools/command/test.py", line 55, in loadTestsFromModule
    tests.append(self.loadTestsFromName(submodule))
  File "/usr/lib/python3.8/unittest/loader.py", line 154, in loadTestsFromName
    module = __import__(module_name)
  File "/home/emlun/dev/yubikey-manager/test/on_yubikey/cli_piv/test_fips.py", line 4, in <module>
    from ..framework import cli_test_suite, yubikey_conditions
  File "/home/emlun/dev/yubikey-manager/test/on_yubikey/framework/__init__.py", line 28, in <module>
    print('{:%.3f} {}'.format(time.time() - start_time, dev))
ValueError: Invalid format specifier
```

and

```
$ DESTRUCTIVE_TEST_YUBIKEY_SERIALS=7800014 python setup.py test
running test
running egg_info
writing yubikey_manager.egg-info/PKG-INFO
writing dependency_links to yubikey_manager.egg-info/dependency_links.txt
writing entry points to yubikey_manager.egg-info/entry_points.txt
writing requirements to yubikey_manager.egg-info/requires.txt
writing top-level names to yubikey_manager.egg-info/top_level.txt
reading manifest file 'yubikey_manager.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: no files found matching 'ChangeLog'
warning: no files found matching 'resources/*'
warning: manifest_maker: MANIFEST.in, line 10: 'recursive-exclude' expects <dir> <pattern1> <pattern2> ...

writing manifest file 'yubikey_manager.egg-info/SOURCES.txt'
running build_ext
Initiating device discovery...
0.002 YubiKey Preview 5.0.2 OTP+FIDO+CCID [CCID] serial: 7800014
0.078 YubiKey Preview 5.0.2 OTP+FIDO+CCID [OTP] serial: 7800014
2.939 YubiKey Preview 5.0.2 OTP+FIDO+CCID [FIDO] serial: 7800014
Run integration tests? This will erase data on the YubiKeys with serial numbers: {7800014}. Make sure these are all keys used for development. [y/N]: y
Device discovery finished in 4.435 s
Starting test instantiation: test.on_yubikey.cli_piv.test_fips ...
Test instantiation completed in 0.054 s
Starting test instantiation: test.on_yubikey.cli_piv.test_generate_cert_and_csr ...
Test instantiation completed in 0.014 s
Starting test instantiation: test.on_yubikey.cli_piv.test_key_management ...
Test instantiation completed in 0.012 s
Starting test instantiation: test.on_yubikey.cli_piv.test_management_key ...
Test instantiation completed in 0.010 s
Starting test instantiation: test.on_yubikey.cli_piv.test_misc ...
Test instantiation completed in 0.012 s
Starting test instantiation: test.on_yubikey.cli_piv.test_pin_puk ...
Test instantiation completed in 0.010 s
Starting test instantiation: test.on_yubikey.test_cli_config ...
Test instantiation completed in 0.011 s
Starting test instantiation: test.on_yubikey.test_cli_misc ...
Test instantiation completed in 0.010 s
Starting test instantiation: test.on_yubikey.test_cli_oath ...
Test instantiation completed in 0.010 s
Starting test instantiation: test.on_yubikey.test_cli_openpgp ...
Test instantiation completed in 0.011 s
Starting test instantiation: test.on_yubikey.test_cli_otp ...
Test instantiation completed in 0.012 s
Starting test instantiation: test.on_yubikey.test_fips_u2f_commands ...
Test instantiation completed in 0.020 s
Starting test instantiation: test.on_yubikey.test_piv ...
Test instantiation completed in 0.024 s
Starting test instantiation: test.on_yubikey.test_opgp ...
Traceback (most recent call last):
  File "setup.py", line 49, in <module>
    setup(
  File "/home/emlun/dev/yubikey-manager/.python-venv/lib/python3.8/site-packages/setuptools/__init__.py", line 145, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python3.8/distutils/core.py", line 148, in setup
    dist.run_commands()
  File "/usr/lib/python3.8/distutils/dist.py", line 966, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3.8/distutils/dist.py", line 985, in run_command
    cmd_obj.run()
  File "/home/emlun/dev/yubikey-manager/.python-venv/lib/python3.8/site-packages/setuptools/command/test.py", line 229, in run
    self.run_tests()
  File "/home/emlun/dev/yubikey-manager/.python-venv/lib/python3.8/site-packages/setuptools/command/test.py", line 247, in run_tests
    test = unittest.main(
  File "/usr/lib/python3.8/unittest/main.py", line 100, in __init__
    self.parseArgs(argv)
  File "/usr/lib/python3.8/unittest/main.py", line 147, in parseArgs
    self.createTests()
  File "/usr/lib/python3.8/unittest/main.py", line 158, in createTests
    self.test = self.testLoader.loadTestsFromNames(self.testNames,
  File "/usr/lib/python3.8/unittest/loader.py", line 220, in loadTestsFromNames
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/usr/lib/python3.8/unittest/loader.py", line 220, in <listcomp>
    suites = [self.loadTestsFromName(name, module) for name in names]
  File "/usr/lib/python3.8/unittest/loader.py", line 191, in loadTestsFromName
    return self.loadTestsFromModule(obj)
  File "/home/emlun/dev/yubikey-manager/.python-venv/lib/python3.8/site-packages/setuptools/command/test.py", line 55, in loadTestsFromModule
    tests.append(self.loadTestsFromName(submodule))
  File "/usr/lib/python3.8/unittest/loader.py", line 191, in loadTestsFromName
    return self.loadTestsFromModule(obj)
  File "/home/emlun/dev/yubikey-manager/.python-venv/lib/python3.8/site-packages/setuptools/command/test.py", line 55, in loadTestsFromModule
    tests.append(self.loadTestsFromName(submodule))
  File "/usr/lib/python3.8/unittest/loader.py", line 191, in loadTestsFromName
    return self.loadTestsFromModule(obj)
  File "/home/emlun/dev/yubikey-manager/.python-venv/lib/python3.8/site-packages/setuptools/command/test.py", line 44, in loadTestsFromModule
    tests.append(module.additional_tests())
  File "/home/emlun/dev/yubikey-manager/test/on_yubikey/framework/__init__.py", line 247, in additional_tests
    (tests, covered_test_names) = _multiply_test_classes_by_devices(
  File "/home/emlun/dev/yubikey-manager/test/on_yubikey/framework/__init__.py", line 190, in _multiply_test_classes_by_devices
    for test_class in _create_test_classes_for_device(
  File "/home/emlun/dev/yubikey-manager/test/on_yubikey/framework/__init__.py", line 146, in _create_test_classes_for_device
    for test_class in create_test_classes(context):
TypeError: 'NoneType' object is not iterable
```
