### PR TITLE
Make fallback log message in list_keys more correct

### DIFF
--- a/ykman/cli/__main__.py
+++ b/ykman/cli/__main__.py
@@ -251,7 +251,9 @@ def list_keys(ctx, serials, readers):
             'Failed to establish CCID context. Is the pcscd service running?')
 
     # List descriptors that failed to open.
-    logger.debug('Failed to open all devices, listing based on descriptors')
+    if len(descriptors) > 0:
+        logger.debug(
+            'Failed to open some devices, listing based on descriptors')
     for desc in descriptors:
         click.echo('{} [{}]'.format(desc.name, desc.mode))
 


### PR DESCRIPTION
If flow passes the `ctx.exit()` on line 222, it will always reach this log statement, even if no devices did in fact fail.