### PR TITLE
util: support enums with dash in UpperCaseChoice

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Install dependencies
         run: |
           brew update
-          brew install ykpers libyubikey libusb swig python
+          brew install ykpers libyubikey libusb swig
           python -m pip install --upgrade pip
           pip install .
 

--- a/ykman/cli/util.py
+++ b/ykman/cli/util.py
@@ -47,7 +47,7 @@ class UpperCaseChoice(click.Choice):
         click.Choice.__init__(self, choices)
 
     def convert(self, value, param, ctx):
-        if value.upper() in self.choices:
+        if value.upper().replace('_', '-') in self.choices:
             return value.upper()
         self.fail(
             'invalid choice: %s. (choose from %s)' % (

--- a/ykman/cli/util.py
+++ b/ykman/cli/util.py
@@ -47,7 +47,7 @@ class UpperCaseChoice(click.Choice):
         click.Choice.__init__(self, choices)
 
     def convert(self, value, param, ctx):
-        if value.upper().replace('_', '-') in self.choices:
+        if value.upper() in self.choices:
             return value.upper()
         self.fail(
             'invalid choice: %s. (choose from %s)' % (
@@ -68,7 +68,7 @@ class EnumChoice(UpperCaseChoice):
 
     def convert(self, value, param, ctx):
         name = super(EnumChoice, self).convert(
-            value.replace('-', '_'), param, ctx)
+            value, param, ctx).replace('-', '_')
         return self.choices_enum[name]
 
 


### PR DESCRIPTION
Currently, `ykman openpgp set-touch` fails when using the option `cached-fixed`. This is a fix for that.

```
$ ykman openpgp set-touch SIG CACHED-FIXED
Usage: ykman openpgp set-touch [OPTIONS] KEY POLICY
Try "ykman openpgp set-touch -h" for help.
Error: Invalid value for "POLICY": invalid choice: CACHED_FIXED. (choose from OFF, ON, FIXED, CACHED, CACHED-FIXED)
```