### PR TITLE
cli: hint at permissions when open device fails

### DIFF
--- a/ykman/cli/__main__.py
+++ b/ykman/cli/__main__.py
@@ -100,8 +100,8 @@ def _run_cmd_for_serial(ctx, cmd, transports, serial):
         except FailedOpeningDeviceException:
             ctx.fail(
                 'Failed connecting to a YubiKey with serial: {}. \
-                        Make sure the application have the required permissions.'.format(
-                            serial))
+                        Make sure the application have the required \
+                            permissions.'.format(serial))
 
 
 def _run_cmd_for_single(ctx, cmd, transports, reader=None):

--- a/ykman/cli/__main__.py
+++ b/ykman/cli/__main__.py
@@ -100,7 +100,7 @@ def _run_cmd_for_serial(ctx, cmd, transports, serial):
         except FailedOpeningDeviceException:
             ctx.fail(
                 'Failed connecting to a YubiKey with serial: {}. \
-                        Make sure you have the correct permissions'.format(
+                        Make sure the application have the required permissions.'.format(
                             serial))
 
 
@@ -131,8 +131,8 @@ def _run_cmd_for_single(ctx, cmd, transports, reader=None):
         try:
             return descriptor.open_device(transports)
         except FailedOpeningDeviceException:
-            ctx.fail('Failed connecting to {} [{}]. Make sure you have \
-                    the correct permissions.'.format(
+            ctx.fail('Failed connecting to {} [{}]. Make sure the application have \
+                    the required permissions.'.format(
                         descriptor.name, descriptor.mode))
     else:
         _disabled_transport(ctx, transports, cmd)

--- a/ykman/cli/__main__.py
+++ b/ykman/cli/__main__.py
@@ -98,8 +98,10 @@ def _run_cmd_for_serial(ctx, cmd, transports, serial):
                     ctx.fail("Command '{}' is not supported by this device."
                              .format(cmd))
         except FailedOpeningDeviceException:
-            ctx.fail('Failed connecting to a YubiKey with serial: {}'
-                     .format(serial))
+            ctx.fail(
+                'Failed connecting to a YubiKey with serial: {}. \
+                        Make sure you have the correct permissions'.format(
+                            serial))
 
 
 def _run_cmd_for_single(ctx, cmd, transports, reader=None):
@@ -129,8 +131,9 @@ def _run_cmd_for_single(ctx, cmd, transports, reader=None):
         try:
             return descriptor.open_device(transports)
         except FailedOpeningDeviceException:
-            ctx.fail('Failed connecting to {} [{}]'.format(
-                descriptor.name, descriptor.mode))
+            ctx.fail('Failed connecting to {} [{}]. Make sure you have \
+                    the correct permissions.'.format(
+                        descriptor.name, descriptor.mode))
     else:
         _disabled_transport(ctx, transports, cmd)
 


### PR DESCRIPTION
Several OS permission restrictions typically makes ykman fail to open the device, causing a error message. Try to hint at the reason in the message, even if we can't be sure.

This should be triggered by:
- Running a FIDO command on recent Windows 10 without administrator privileges.
- Running a OTP command on macOS Catalina, without making the application to allow "Input Monitoring" in the System Settings. The OS typically prompts for this, at least once.
- Possibly other cases (maybe missing udev on Linux? Not tested.)

Related: https://github.com/Yubico/yubikey-manager-qt/pull/223