### PR TITLE
Fix test warning about wrong assert function

### DIFF
--- a/test/on_yubikey/cli_piv/test_misc.py
+++ b/test/on_yubikey/cli_piv/test_misc.py
@@ -25,6 +25,6 @@ def additional_tests(ykman_cli):
                 '-m', DEFAULT_MANAGEMENT_KEY, '0x5f0001',
                 '-', input='test data')
             output = ykman_cli('piv', 'read-object', '0x5f0001')
-            self.assertEquals('test data\n', output)
+            self.assertEqual('test data\n', output)
 
     return [Misc]


### PR DESCRIPTION
```
test_write_read_object (test.on_yubikey.cli_piv.test_misc.additional_tests.<locals>.Misc_5.0.3_1234567) ... /home/emlun/dev/yubikey-manager/test/on_yubikey/cli_piv/test_misc.py:28:
DeprecationWarning: Please use assertEqual instead.
  self.assertEquals('test data\n', output)
ok
```