### PR TITLE
oath: code -s gave wrong error message

### DIFF
--- a/ykman/cli/oath.py
+++ b/ykman/cli/oath.py
@@ -372,7 +372,7 @@ def code(ctx, show_hidden, query, single):
         _error_multiple_hits(ctx, [cr for cr, c in creds])
 
     elif single and len(creds) == 0:
-        ctx.fail('No credential found.')
+        ctx.fail('No matching credential found.')
 
     if single and creds:
         click.echo(creds[0][1].value)

--- a/ykman/cli/oath.py
+++ b/ykman/cli/oath.py
@@ -368,10 +368,10 @@ def code(ctx, show_hidden, query, single):
             if e.sw == SW.SECURITY_CONDITION_NOT_SATISFIED:
                 ctx.fail('Touch credential timed out!')
 
-    elif single:
+    elif single and len(creds) > 1:
         _error_multiple_hits(ctx, [cr for cr, c in creds])
 
-    if single:
+    if single and creds:
         click.echo(creds[0][1].value)
     else:
         creds.sort()

--- a/ykman/cli/oath.py
+++ b/ykman/cli/oath.py
@@ -371,6 +371,9 @@ def code(ctx, show_hidden, query, single):
     elif single and len(creds) > 1:
         _error_multiple_hits(ctx, [cr for cr, c in creds])
 
+    elif single and len(creds) == 0:
+        ctx.fail('No credential found.')
+
     if single and creds:
         click.echo(creds[0][1].value)
     else:


### PR DESCRIPTION
Found this by accident, but it prints the multiple hits error when there is no hits.