### PR TITLE
replace all ctx.fail calls with custom func

### DIFF
--- a/ykman/cli/__main__.py
+++ b/ykman/cli/__main__.py
@@ -131,7 +131,7 @@ def _run_cmd_for_single(ctx, cmd, transports, reader=None):
         try:
             return descriptor.open_device(transports)
         except FailedOpeningDeviceException:
-            cli_fail('Failed connecting to {} [{}]. Make sure the application have \
+            cli_fail('Failed connecting to {} [{}]. Make sure the application has \
                     the required permissions.'.format(
                         descriptor.name, descriptor.mode))
     else:

--- a/ykman/cli/mode.py
+++ b/ykman/cli/mode.py
@@ -27,7 +27,7 @@
 
 from __future__ import absolute_import
 
-from .util import click_force_option
+from .util import click_force_option, cli_fail
 from ..util import Mode, TRANSPORT
 from ..driver import ModeSwitchError
 import logging
@@ -52,7 +52,7 @@ def _parse_mode_string(ctx, param, mode):
         mode_int = int(mode)
         return Mode.from_code(mode_int)
     except IndexError:
-        ctx.fail('Invalid mode: {}'.format(mode_int))
+        cli_fail('Invalid mode: {}'.format(mode_int))
     except ValueError:
         pass  # Not a numeric mode, parse string
 
@@ -70,7 +70,7 @@ def _parse_mode_string(ctx, param, mode):
             for t in filter(None, re.split(r'[+]+', mode.upper())):
                 transports.add(_parse_transport_string(t))
     except ValueError:
-        ctx.fail('Invalid mode string: {}'.format(mode))
+        cli_fail('Invalid mode string: {}'.format(mode))
 
     return Mode(sum(transports))
 
@@ -119,7 +119,7 @@ def mode(ctx, mode, touch_eject, autoeject_timeout, chalresp_timeout, force):
         if mode.transports != TRANSPORT.CCID:
             autoeject = None
             if touch_eject:
-                ctx.fail('--touch-eject can only be used when setting'
+                cli_fail('--touch-eject can only be used when setting'
                          ' CCID-only mode')
 
         if not force:
@@ -129,7 +129,7 @@ def mode(ctx, mode, touch_eject, autoeject_timeout, chalresp_timeout, force):
             elif not dev.has_mode(mode):
                 click.echo('Mode {} is not supported on this YubiKey!'
                            .format(mode))
-                ctx.fail('Use --force to attempt to set it anyway.')
+                cli_fail('Use --force to attempt to set it anyway.')
             force or click.confirm('Set mode of YubiKey to {}?'.format(mode),
                                    abort=True, err=True)
 

--- a/ykman/cli/util.py
+++ b/ykman/cli/util.py
@@ -81,7 +81,7 @@ def click_callback(invoke_on_missing=False):
             try:
                 return f(ctx, param, val)
             except Exception as e:
-                ctx.fail('Invalid value for "{}": {}'.format(
+                cli_fail('Invalid value for "{}": {}'.format(
                     param.name, str(e)))
         return inner
     return wrap
@@ -162,3 +162,12 @@ def prompt_for_touch():
         click.echo('Touch your YubiKey...', err=True)
     except Exception:
         sys.stderr.write('Touch your YubiKey...\n')
+
+
+def cli_fail(message, error_code=1):
+    try:
+        click.echo("Error: {}".format(message), err=True)
+        sys.exit(error_code)
+    except Exception:
+        sys.stderr.writecl("Error: {}\n".format(message))
+        sys.exit(error_code)

--- a/ykman/cli/util.py
+++ b/ykman/cli/util.py
@@ -169,5 +169,5 @@ def cli_fail(message, error_code=1):
         click.echo("Error: {}".format(message), err=True)
         sys.exit(error_code)
     except Exception:
-        sys.stderr.writecl("Error: {}\n".format(message))
+        sys.stderr.write("Error: {}\n".format(message))
         sys.exit(error_code)


### PR DESCRIPTION
Use a custom `cli_fail` function that doesn't print usage info.

Fixes #296