### PR TITLE
Better error handling when failing to open CCID context

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ install_requires = [
 ]
 tests_require = []
 if sys.version_info < (3, 3):
-    tests_require.append('mock')
+    tests_require.append('mock < 4')
 if sys.version_info < (3, 4):
     install_requires.append('enum34')
 if sys.platform == 'win32':

--- a/ykman/cli/__main__.py
+++ b/ykman/cli/__main__.py
@@ -131,9 +131,10 @@ def _run_cmd_for_single(ctx, cmd, transports, reader=None):
         try:
             return descriptor.open_device(transports)
         except FailedOpeningDeviceException:
-            ctx.fail('Failed connecting to {} [{}]. Make sure the application have \
-                    the required permissions.'.format(
-                        descriptor.name, descriptor.mode))
+            ctx.fail('Failed connecting to {} [{}]. '
+                     'Make sure the application has the '
+                     'required permissions.'
+                     .format(descriptor.name, descriptor.mode))
     else:
         _disabled_transport(ctx, transports, cmd)
 

--- a/ykman/descriptor.py
+++ b/ykman/descriptor.py
@@ -160,7 +160,7 @@ def _list_drivers(transports):
                     yield dev
         except smartcard.pcsc.PCSCExceptions.EstablishContextException:
             logger.debug('Failed to establish CCID context. '
-                         'Is the pcscd service running?')
+                         'Is the pcscd/smart card service running?')
     if TRANSPORT.OTP & transports:
         for dev in open_otp():
             if dev:

--- a/ykman/descriptor.py
+++ b/ykman/descriptor.py
@@ -35,8 +35,9 @@ from .driver_otp import open_devices as open_otp
 from .native.pyusb import get_usb_backend
 
 import logging
-import usb.core
+import smartcard
 import time
+import usb.core
 
 logger = logging.getLogger(__name__)
 
@@ -153,9 +154,13 @@ def get_descriptors():
 
 def _list_drivers(transports):
     if TRANSPORT.CCID & transports:
-        for dev in open_ccid():
-            if dev:
-                yield dev
+        try:
+            for dev in open_ccid():
+                if dev:
+                    yield dev
+        except smartcard.pcsc.PCSCExceptions.EstablishContextException:
+            logger.debug('Failed to establish CCID context. '
+                         'Is the pcscd service running?')
     if TRANSPORT.OTP & transports:
         for dev in open_otp():
             if dev:


### PR DESCRIPTION
Solves the issue when Smart Card Service on Windows is disabled and ykman qt could not open at all.

Also fixed a typo.