### PR TITLE
Migrate to tox

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -qq libykpers-1-1 swig libpcsclite-dev
           python -m pip install --upgrade pip
+          pip install tox
           pip install .
 
       - name: Lint with flake8
@@ -34,7 +35,14 @@ jobs:
           flake8 .
 
       - name: Run unit tests
-        run: python setup.py test
+        run: tox -e py27
+        # tox manages Python environments internally
+        if: matrix.python == '2.x'
+
+      - name: Run unit tests
+        run: tox -e py38
+        # tox manages Python environments internally
+        if: matrix.python == '3.x'
 
       - name: Run CLI
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         run: pip install -r test_requirements.txt
 
       - name: Run unit tests
-        run: tox
+        run: tox -- -v
 
       - name: Run CLI
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,9 +34,6 @@ jobs:
           pip install flake8
           flake8 .
 
-      - name: Install test dependencies
-        run: pip install -r test_requirements.txt
-
       - name: Run unit tests
         run: tox -- -v
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,15 +34,11 @@ jobs:
           pip install flake8
           flake8 .
 
-      - name: Run unit tests
-        run: tox -e py27
-        # tox manages Python environments internally
-        if: matrix.python == '2.x'
+      - name: Install test dependencies
+        run: pip install -r test_requirements.txt
 
       - name: Run unit tests
-        run: tox -e py38
-        # tox manages Python environments internally
-        if: matrix.python == '3.x'
+        run: tox
 
       - name: Run CLI
         run: |

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -19,7 +19,7 @@ jobs:
           pip install .
 
       - name: Run unit tests
-        run: tox
+        run: tox -- -v
 
       - name: Run CLI
         run: |

--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -15,10 +15,11 @@ jobs:
           brew update
           brew install ykpers libyubikey libusb swig
           python -m pip install --upgrade pip
+          pip install tox
           pip install .
 
       - name: Run unit tests
-        run: python setup.py test
+        run: tox
 
       - name: Run CLI
         run: |

--- a/.github/workflows/source-package.yml
+++ b/.github/workflows/source-package.yml
@@ -25,7 +25,7 @@ jobs:
           pip install .
 
       - name: Run unit tests
-        run: tox
+        run: tox -- -v
 
       - name: Create source package
         run: |

--- a/.github/workflows/source-package.yml
+++ b/.github/workflows/source-package.yml
@@ -21,10 +21,11 @@ jobs:
           sudo apt-get update
           sudo apt-get install -qq libykpers-1-1 swig libpcsclite-dev
           python -m pip install --upgrade pip
+          pip install tox
           pip install .
 
       - name: Run unit tests
-        run: python setup.py test
+        run: tox
 
       - name: Create source package
         run: |

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,7 +25,7 @@ jobs:
         shell: powershell
 
       - name: Run unit tests
-        run: tox
+        run: tox -- -v
 
       - name: Run CLI
         shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -20,11 +20,12 @@ jobs:
           7z x libusb-1.0.22.7z
           Copy-Item .\MS64\dll\*.dll .\ykman\native -Force
           python -m pip install --upgrade pip
+          pip install tox
           pip install --no-cache-dir -e .
         shell: powershell
 
       - name: Run unit tests
-        run: python setup.py test
+        run: tox
 
       - name: Run CLI
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.pyc
 *.egg-info
 *.egg/
+.tox/
 *.vagrant
 vagrant/development/*.log
 .eggs/

--- a/doc/development.adoc
+++ b/doc/development.adoc
@@ -57,6 +57,11 @@ To run unit tests:
 
     $ tox
 
+To run with multiple Python versions (requires all those interpreters to be installed):
+
+    $ tox -e py27,py38
+
+
 === Integration tests
 
 WARNING: ONLY run these on dedicated developer keys, as it will permanently delete data on the device(s)!

--- a/doc/development.adoc
+++ b/doc/development.adoc
@@ -68,7 +68,7 @@ WARNING: ONLY run these on dedicated developer keys, as it will permanently dele
 
 To run integration tests, indicate the serial numbers (given by `ykman list`) of the YubiKeys to test with:
 
-   $ DESTRUCTIVE_TEST_YUBIKEY_SERIALS=123456,234567 tox
+   $ DESTRUCTIVE_TEST_YUBIKEY_SERIALS=123456,234567 tox -e integration-test
 
 The integration test suite will automatically identify which test cases can be run with the
 available YubiKeys, and run those test cases for each eligible YubiKey. See

--- a/doc/development.adoc
+++ b/doc/development.adoc
@@ -53,6 +53,10 @@ To use these:
 
 === Unit tests
 
+First, install https://tox.readthedocs.io/en/latest/[tox] if you haven't already:
+
+    $ pip install tox
+
 To run unit tests:
 
     $ tox

--- a/doc/development.adoc
+++ b/doc/development.adoc
@@ -63,7 +63,7 @@ WARNING: ONLY run these on dedicated developer keys, as it will permanently dele
 
 To run integration tests, indicate the serial numbers (given by `ykman list`) of the YubiKeys to test with:
 
-   $ DESTRUCTIVE_TEST_YUBIKEY_SERIALs=123456,234567 tox
+   $ DESTRUCTIVE_TEST_YUBIKEY_SERIALS=123456,234567 tox
 
 The integration test suite will automatically identify which test cases can be run with the
 available YubiKeys, and run those test cases for each eligible YubiKey. See

--- a/doc/development.adoc
+++ b/doc/development.adoc
@@ -55,7 +55,7 @@ To use these:
 
 To run unit tests:
 
-    $ python setup.py test
+    $ tox
 
 === Integration tests
 
@@ -63,7 +63,7 @@ WARNING: ONLY run these on dedicated developer keys, as it will permanently dele
 
 To run integration tests, indicate the serial numbers (given by `ykman list`) of the YubiKeys to test with:
 
-   $ DESTRUCTIVE_TEST_YUBIKEY_SERIALs=123456,234567 python setup.py test
+   $ DESTRUCTIVE_TEST_YUBIKEY_SERIALs=123456,234567 tox
 
 The integration test suite will automatically identify which test cases can be run with the
 available YubiKeys, and run those test cases for each eligible YubiKey. See

--- a/setup.py
+++ b/setup.py
@@ -33,9 +33,6 @@ install_requires = [
     'six', 'pyscard', 'pyusb', 'click',
     'cryptography', 'pyopenssl', 'fido2 >= 0.7'
 ]
-tests_require = []
-if sys.version_info < (3, 3):
-    tests_require.append('mock < 4')
 if sys.version_info < (3, 4):
     install_requires.append('enum34')
 if sys.platform == 'win32':
@@ -64,8 +61,6 @@ setup(
     install_requires=install_requires,
     package_data={'ykman': ['VERSION']},
     include_package_data=True,
-    test_suite='test',
-    tests_require=tests_require,
     classifiers=[
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',

--- a/test/on_yubikey/framework/__init__.py
+++ b/test/on_yubikey/framework/__init__.py
@@ -239,7 +239,7 @@ def _make_test_suite_decorator(
     '''
     def decorate(create_test_classes):
         def additional_tests():
-            if _test_serials is None:
+            if sys.version_info < (3, 0):
                 # Workaround since framework crashes in py2
                 # This if statement can be deleted when py2 support is dropped
                 return unittest.TestSuite()

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,0 +1,1 @@
+mock; python_version < '3'

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,1 +1,0 @@
-mock; python_version < '3'

--- a/tox.ini
+++ b/tox.ini
@@ -4,13 +4,15 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27,py38
+envlist = py
 
 [testenv]
 deps =
     -r{toxinidir}/test_requirements.txt
+commands_pre =
+    python --version
 commands =
-    python -m unittest {posargs}
+    python -m unittest discover {posargs}
 passenv =
     py38: DESTRUCTIVE_TEST_YUBIKEY_SERIALS
     py38: DESTRUCTIVE_TEST_DO_NOT_PROMPT

--- a/tox.ini
+++ b/tox.ini
@@ -7,12 +7,25 @@
 envlist = py
 
 [testenv]
+# Pure software tests
+# Invoke as `tox`, `tox -e py27` etc.
 deps =
     -r{toxinidir}/test_requirements.txt
 commands_pre =
     python --version
 commands =
     python -m unittest discover {posargs}
+
+[testenv:integration-test]
+# Tests with real YubiKeys
+# Invoke as `tox -e integration-test`
+basepython = python
+deps =
+    {[testenv]deps}
+commands_pre =
+    {[testenv]commands_pre}
+commands =
+    python setup.py test
 passenv =
-    py38: DESTRUCTIVE_TEST_YUBIKEY_SERIALS
-    py38: DESTRUCTIVE_TEST_DO_NOT_PROMPT
+    DESTRUCTIVE_TEST_YUBIKEY_SERIALS
+    DESTRUCTIVE_TEST_DO_NOT_PROMPT

--- a/tox.ini
+++ b/tox.ini
@@ -7,8 +7,10 @@
 envlist = py27,py38
 
 [testenv]
+deps =
+    -r{toxinidir}/test_requirements.txt
 commands =
-    python setup.py test {posargs}
+    python -m unittest {posargs}
 passenv =
     py38: DESTRUCTIVE_TEST_YUBIKEY_SERIALS
     py38: DESTRUCTIVE_TEST_DO_NOT_PROMPT

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,14 @@
+# tox (https://tox.readthedocs.io/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py27,py38
+
+[testenv]
+commands =
+    python setup.py test {posargs}
+passenv =
+    py38: DESTRUCTIVE_TEST_YUBIKEY_SERIALS
+    py38: DESTRUCTIVE_TEST_DO_NOT_PROMPT

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist = py
 # Pure software tests
 # Invoke as `tox`, `tox -e py27` etc.
 deps =
-    -r{toxinidir}/test_requirements.txt
+    mock; python_version < '3'
 commands_pre =
     python --version
 commands =


### PR DESCRIPTION
`python setup.py test` is deprecated, see
https://setuptools.readthedocs.io/en/latest/history.html#v41-5-0:

>#1878: Formally deprecated the test command, with the recommendation
that users migrate to tox.