### PR TITLE
drivers: improve error handling and debugging

### DIFF
--- a/ykman/descriptor.py
+++ b/ykman/descriptor.py
@@ -153,27 +153,24 @@ def get_descriptors():
 
 
 def _list_drivers(transports):
+    res = []
     if TRANSPORT.CCID & transports:
         try:
-            for dev in open_ccid():
-                if dev:
-                    yield dev
+            res.extend(open_ccid())
         except smartcard.pcsc.PCSCExceptions.EstablishContextException:
             logger.debug('Failed to establish CCID context. '
                          'Is the pcscd/smart card service running?')
     if TRANSPORT.OTP & transports:
-        for dev in open_otp():
-            if dev:
-                yield dev
+        res.extend(open_otp())
     if TRANSPORT.FIDO & transports:
-        for dev in open_fido():
-            if dev:
-                yield dev
+        res.extend(open_fido())
+    return res
 
 
 def list_devices(transports=sum(TRANSPORT)):
-    for d in _list_drivers(transports):
-        yield YubiKey(Descriptor.from_driver(d), d)
+    return [
+        YubiKey(
+            Descriptor.from_driver(d), d) for d in _list_drivers(transports)]
 
 
 def _open_driver(transports, serial, key_type, mode, attempts):

--- a/ykman/descriptor.py
+++ b/ykman/descriptor.py
@@ -156,14 +156,24 @@ def _list_drivers(transports):
     res = []
     if TRANSPORT.CCID & transports:
         try:
-            res.extend(open_ccid())
+            ccid_drivers = open_ccid()
+            if not ccid_drivers:
+                logger.debug(
+                    'Trying to list CCID drivers, but no readers found.')
+            res.extend(ccid_drivers)
         except smartcard.pcsc.PCSCExceptions.EstablishContextException:
             logger.debug('Failed to establish CCID context. '
                          'Is the pcscd/smart card service running?')
     if TRANSPORT.OTP & transports:
-        res.extend(open_otp())
+        otp_drivers = open_otp()
+        if not otp_drivers:
+            logger.debug('Trying to list OTP drivers, but none found.')
+        res.extend(otp_drivers)
     if TRANSPORT.FIDO & transports:
-        res.extend(open_fido())
+        fido_drivers = open_fido()
+        if not fido_drivers:
+            logger.debug('Trying to list FIDO drivers, but none found.')
+        res.extend(fido_drivers)
     return res
 
 

--- a/ykman/descriptor.py
+++ b/ykman/descriptor.py
@@ -153,14 +153,14 @@ def get_descriptors():
 
 
 def _list_drivers(transports):
-    res = []
+    drivers = []
     if TRANSPORT.CCID & transports:
         try:
             ccid_drivers = open_ccid()
             if not ccid_drivers:
                 logger.debug(
                     'Trying to list CCID drivers, but no readers found.')
-            res.extend(ccid_drivers)
+            drivers.extend(ccid_drivers)
         except smartcard.pcsc.PCSCExceptions.EstablishContextException:
             logger.debug('Failed to establish CCID context. '
                          'Is the pcscd/smart card service running?')
@@ -168,13 +168,13 @@ def _list_drivers(transports):
         otp_drivers = open_otp()
         if not otp_drivers:
             logger.debug('Trying to list OTP drivers, but none found.')
-        res.extend(otp_drivers)
+        drivers.extend(otp_drivers)
     if TRANSPORT.FIDO & transports:
         fido_drivers = open_fido()
         if not fido_drivers:
             logger.debug('Trying to list FIDO drivers, but none found.')
-        res.extend(fido_drivers)
-    return res
+        drivers.extend(fido_drivers)
+    return drivers
 
 
 def list_devices(transports=sum(TRANSPORT)):

--- a/ykman/driver_ccid.py
+++ b/ykman/driver_ccid.py
@@ -323,6 +323,7 @@ def list_readers():
 
 
 def open_devices(name_filter=YK_READER_NAME):
+    res = []
     readers = list_readers()
     while readers:
         try_again = []
@@ -331,7 +332,7 @@ def open_devices(name_filter=YK_READER_NAME):
                 try:
                     conn = reader.createConnection()
                     conn.connect()
-                    yield CCIDDriver(conn, reader.name)
+                    res.append(CCIDDriver(conn, reader.name))
                 except CardConnectionException:
                     try_again.append(reader)
                 except Exception as e:
@@ -341,4 +342,5 @@ def open_devices(name_filter=YK_READER_NAME):
         if try_again and kill_scdaemon():
             readers = try_again
         else:
-            return
+            return res
+    return res

--- a/ykman/driver_ccid.py
+++ b/ykman/driver_ccid.py
@@ -323,7 +323,7 @@ def list_readers():
 
 
 def open_devices(name_filter=YK_READER_NAME):
-    res = []
+    devices = []
     readers = list_readers()
     while readers:
         try_again = []
@@ -332,7 +332,7 @@ def open_devices(name_filter=YK_READER_NAME):
                 try:
                     conn = reader.createConnection()
                     conn.connect()
-                    res.append(CCIDDriver(conn, reader.name))
+                    devices.append(CCIDDriver(conn, reader.name))
                 except CardConnectionException:
                     try_again.append(reader)
                 except Exception as e:
@@ -342,5 +342,5 @@ def open_devices(name_filter=YK_READER_NAME):
         if try_again and kill_scdaemon():
             readers = try_again
         else:
-            return res
-    return res
+            return devices
+    return devices

--- a/ykman/driver_fido.py
+++ b/ykman/driver_fido.py
@@ -94,8 +94,10 @@ def descriptor_filter(desc):
 
 
 def open_devices():
+    res = []
     for dev in CtapHidDevice.list_devices(descriptor_filter):
         try:
-            yield FidoDriver(dev)
+            res.append(FidoDriver(dev))
         except Exception as e:
             logger.debug('Failed opening FIDO device', exc_info=e)
+    return res

--- a/ykman/driver_fido.py
+++ b/ykman/driver_fido.py
@@ -94,10 +94,10 @@ def descriptor_filter(desc):
 
 
 def open_devices():
-    res = []
+    devices = []
     for dev in CtapHidDevice.list_devices(descriptor_filter):
         try:
-            res.append(FidoDriver(dev))
+            devices.append(FidoDriver(dev))
         except Exception as e:
             logger.debug('Failed opening FIDO device', exc_info=e)
-    return res
+    return devices

--- a/ykman/driver_otp.py
+++ b/ykman/driver_otp.py
@@ -210,11 +210,12 @@ class OTPDriver(AbstractDriver):
 
 
 def open_devices():
+    res = []
     if not libversion:
         logger.error(MISSING_LIBYKPERS_MSG)
-        return
+        return res
     if libversion < (1, 18):
-        yield OTPDriver(ykpers.yk_open_first_key())
+        res.append(OTPDriver(ykpers.yk_open_first_key()))
     else:
         for i in range(255):
             dev = ykpers.yk_open_key(i)
@@ -222,4 +223,5 @@ def open_devices():
                 logger.debug('Failed to open key at position %s', i)
                 break
             logger.debug('Success in opening key at position %s', i)
-            yield OTPDriver(dev)
+            res.append(OTPDriver(dev))
+    return res

--- a/ykman/driver_otp.py
+++ b/ykman/driver_otp.py
@@ -210,12 +210,12 @@ class OTPDriver(AbstractDriver):
 
 
 def open_devices():
-    res = []
+    devices = []
     if not libversion:
         logger.error(MISSING_LIBYKPERS_MSG)
-        return res
+        return devices
     if libversion < (1, 18):
-        res.append(OTPDriver(ykpers.yk_open_first_key()))
+        devices.append(OTPDriver(ykpers.yk_open_first_key()))
     else:
         for i in range(255):
             dev = ykpers.yk_open_key(i)
@@ -223,5 +223,5 @@ def open_devices():
                 logger.debug('Failed to open key at position %s', i)
                 break
             logger.debug('Success in opening key at position %s', i)
-            res.append(OTPDriver(dev))
-    return res
+            devices.append(OTPDriver(dev))
+    return devices


### PR DESCRIPTION
- Move to lists instead of generators when dealing with the drivers, to be able to reason about the full set of drivers available. For example if we have two yubikeys reporting CCID mode enabled, but only one CCID reader visible to the OS, something might be wrong.

- Add some debug logging when the there is no drivers available for the transports asked for.