### PR TITLE
list: try all transports

### DIFF
--- a/ykman/cli/__main__.py
+++ b/ykman/cli/__main__.py
@@ -229,7 +229,7 @@ def list_keys(ctx, serials, readers):
     handled_serials = set()
 
     try:
-        for dev in list_devices(transports=TRANSPORT.CCID):
+        for dev in list_devices():
             if dev.key_type == YUBIKEY.SKY:
                 # We have nothing to match on, so just drop a SKY descriptor
                 d = next(x for x in descriptors if x.key_type == YUBIKEY.SKY)


### PR DESCRIPTION
This behavior was changed in https://github.com/Yubico/yubikey-manager/commit/c838a4d6f2a9350a6c1feb2956695d1a3c103f37 , possibly by mistake.