### PR TITLE
pre-commit cleanups

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,10 +29,11 @@ jobs:
           pip install tox
           pip install .
 
-      - name: Lint with flake8
+      - name: Run pre-commit hooks
         run: |
-          pip install flake8
-          flake8 .
+          pip install pre-commit
+          pre-commit install
+          pre-commit run --all-files
 
       - name: Run unit tests
         run: tox -- -v

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,5 @@
 repos:
--   repo: git://github.com/pre-commit/pre-commit-hooks
-    sha: v1.1.1
-    hooks:
-    -   id: flake8
-    -   id: double-quote-string-fixer
+- repo: git://github.com/pre-commit/pre-commit-hooks
+  rev: v2.5.0
+  hooks:
+    - id: double-quote-string-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,7 @@ repos:
   rev: v2.5.0
   hooks:
     - id: double-quote-string-fixer
+- repo: https://gitlab.com/pycqa/flake8
+  rev: 3.7.9
+  hooks:
+    - id: flake8


### PR DESCRIPTION
- Use non-deprecated flake8 hook
- Make sure the same checks are done on CI and locally by running pre-commit in GitHub Actions