### PR TITLE
fido: fix delete command query qualifiers

### DIFF
--- a/ykman/cli/fido.py
+++ b/ykman/cli/fido.py
@@ -149,7 +149,10 @@ def delete(ctx, query, pin, force):
     try:
         hits = [
             cred for cred in controller.get_resident_credentials(pin)
-            if query.lower() in cred.user_name or query.lower() in cred.rp_id
+            if query.lower() in cred.user_name.lower() or
+            query.lower() in cred.rp_id.lower() or
+            query.lower() in '{} ({})'.format(
+                cred.user_name, cred.rp_id).lower()
         ]
         if len(hits) == 0:
             ctx.fail('No matches, nothing to be done.')


### PR DESCRIPTION
This fixes two issues in `ykman fido delete`:

- .lower() was called on the query but not on the username or rp id
- there was no way to fully qualify a username + rp id, in the way they are presented by `ykman fido list`