### PR TITLE
device: fix check for new capabilities

### DIFF
--- a/ykman/device.py
+++ b/ykman/device.py
@@ -249,7 +249,7 @@ class YubiKey(object):
                 self._can_mode_switch = False
 
         # Fix usb_enabled
-        if not config.usb_enabled:
+        if not self._can_write_config:
             usb_enabled = config.usb_supported
             if not TRANSPORT.has(self.mode.transports, TRANSPORT.OTP):
                 usb_enabled &= ~APPLICATION.OTP


### PR DESCRIPTION
Let's only use the response from the GET CAPABILITIES command on YubiKeys with firmware version 5 or higher, since YubiKey 4 in some cases seem to report incorrectly. 

Testing:
- Make sure the `ykman info` command works correctly for a few devices in different modes.