### PR TITLE
ccid: prevent closing same connection twice

### DIFF
--- a/ykman/driver_ccid.py
+++ b/ykman/driver_ccid.py
@@ -266,8 +266,10 @@ class CCIDDriver(AbstractDriver):
         self.send_apdu(0, MGR_INS.SET_MODE, SLOT.DEVICE_CONFIG, 0, mode_data)
 
     def close(self):
-        logger.debug('Close %s', self)
-        self._conn.disconnect()
+        if self._conn is not None:
+            logger.debug('Close %s', self)
+            self._conn.disconnect()
+            self._conn = None
 
     def __del__(self):
         logger.debug('Destroy %s', self)


### PR DESCRIPTION
Without this fix, CCID connections would typically be closed twice, once by the destructor and once by the caller. I don't think this affects much, but it's incorrect and makes the debug log more confusing.

driver_otp.py have a similar check.

See the log below for an example:

```
$ ykman --log-level DEBUG oath info
2020-05-27T08:22:44+0200 INFO [ykman.logging_setup.setup:59] Initialized logging for ykman version: 3.1.1
2020-05-27T08:22:44+0200 DEBUG [ykman.descriptor.Descriptor.open_device:88] transports: 0x4, self.mode.transports: 0x6
2020-05-27T08:22:44+0200 DEBUG [ykman.descriptor.open_device:93] Opening driver for serial: None, type: YUBIKEY.YK4, mode: FIDO+CCID
2020-05-27T08:22:44+0200 DEBUG [ykman.descriptor.open_device:95] Attempt 1 of 10
2020-05-27T08:22:44+0200 DEBUG [ykman.descriptor.open_device:99] Found driver: <ykman.driver_ccid.CCIDDriver object at 0x10320cc50>, key_type: YUBIKEY.YK4, mode: FIDO+CCID
2020-05-27T08:22:44+0200 DEBUG [ykman.device.__init__:198] Read config from device...
2020-05-27T08:22:44+0200 DEBUG [ykman.driver_ccid.send_apdu:228] SEND: b'00a4040008a000000527471117'
2020-05-27T08:22:44+0200 DEBUG [ykman.driver_ccid.send_apdu:230] RECV: b'5669727475616c206d6772202d2046572076657273696f6e20342e332e349000'
2020-05-27T08:22:44+0200 DEBUG [ykman.driver_ccid.send_apdu:228] SEND: b'001d000000'
2020-05-27T08:22:44+0200 DEBUG [ykman.driver_ccid.send_apdu:230] RECV: b'0c0101ff0204005b1a4403013e9000'
2020-05-27T08:22:44+0200 DEBUG [ykman.device.__init__:200] Success!
2020-05-27T08:22:44+0200 DEBUG [ykman.driver_ccid.send_apdu:228] SEND: b'00a4040007a0000005272001'
2020-05-27T08:22:44+0200 DEBUG [ykman.driver_ccid.send_apdu:230] RECV: b'040304020a00050f00009000'
2020-05-27T08:22:44+0200 DEBUG [ykman.driver_ccid.send_apdu:228] SEND: b'00a4040007a0000005272101'
2020-05-27T08:22:44+0200 DEBUG [ykman.driver_ccid.send_apdu:230] RECV: b'7903040304710888d5a1db741c7d4f9000'
OATH version: 4.3.4
Password protection disabled
2020-05-27T08:22:44+0200 DEBUG [ykman.driver_ccid.close:269] Close <ykman.driver_ccid.CCIDDriver object at 0x10320cc50>
2020-05-27T08:22:44+0200 DEBUG [ykman.driver_ccid.__del__:273] Destroy <ykman.driver_ccid.CCIDDriver object at 0x10320cc50>
2020-05-27T08:22:44+0200 DEBUG [ykman.driver_ccid.close:269] Close <ykman.driver_ccid.CCIDDriver object at 0x10320cc50>
```