### PR TITLE
opgp: handle failed KDF attempt on NEO

### DIFF
--- a/ykman/opgp.py
+++ b/ykman/opgp.py
@@ -365,11 +365,14 @@ class OpgpController(object):
         self.send_apdu(0, INS.ACTIVATE, 0, 0)
 
     def _get_kdf(self):
-        data = self._get_data(DO.KDF)
-        if data == b'\x81\x01\x00':
+        try:
+            data = self._get_data(DO.KDF)
+            if data == b'\x81\x01\x00':
+                return None
+            else:
+                return Kdf(data)
+        except APDUError:
             return None
-        else:
-            return Kdf(data)
 
     def _verify(self, pw, pin):
         try:


### PR DESCRIPTION
All `openpgp` commands that requires verification currently fails on a YubiKey NEO, because the attempt to read the KDF data. See below. This fix handles the error response.

Introduced in #325 , so the bug is not in any released version yet.

```
Set PIN retry counters to: 10 10 10? [y/N]: y
2020-05-27T13:30:58+0200 DEBUG [ykman.driver_ccid.send_apdu:228] SEND: b'00ca00f900'
2020-05-27T13:30:58+0200 DEBUG [ykman.driver_ccid.send_apdu:230] RECV: b'6a83'
2020-05-27T13:30:58+0200 DEBUG [ykman.driver_ccid.send_apdu:228] SEND: b'00ca00c400'
2020-05-27T13:30:58+0200 DEBUG [ykman.driver_ccid.send_apdu:230] RECV: b'007f7f7f0303039000'
2020-05-27T13:30:58+0200 DEBUG [ykman.driver_ccid.close:270] Close <ykman.driver_ccid.CCIDDriver object at 0x106d23150>
2020-05-27T13:30:58+0200 ERROR [ykman.cli.__main__.main:276] Error
Traceback (most recent call last):
  File "/Users/d.heyman/code/yubikey-manager/ykman/opgp.py", line 377, in _verify
    kdf = self._get_kdf()
  File "/Users/d.heyman/code/yubikey-manager/ykman/opgp.py", line 368, in _get_kdf
    data = self._get_data(DO.KDF)
  File "/Users/d.heyman/code/yubikey-manager/ykman/opgp.py", line 328, in _get_data
    return self.send_cmd(0, INS.GET_DATA, do >> 8, do & 0xff)
  File "/Users/d.heyman/code/yubikey-manager/ykman/opgp.py", line 324, in send_cmd
    raise APDUError(resp, sw)
ykman.driver_ccid.APDUError: APDU error: SW=0x6a83
```