### PR TITLE
add Bandit security scanner and suppress some of the warnings

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,2 @@
+[bandit]
+exclude: /test

--- a/.bandit
+++ b/.bandit
@@ -1,2 +1,2 @@
 [bandit]
-exclude: /test
+exclude: /test,/.tox

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,13 +34,10 @@ jobs:
         run: |
           pip install pre-commit
           pre-commit install
-          pre-commit run --all-files
+          pre-commit run --all-files --verbose
 
       - name: Run unit tests
         run: tox -- -v
-
-      - name: Run bandit
-        run: bandit -r .
 
       - name: Run CLI
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install tox
           pip install .
+          pip install bandit
 
       - name: Run pre-commit hooks
         run: |
@@ -37,6 +38,9 @@ jobs:
 
       - name: Run unit tests
         run: tox -- -v
+
+      - name: Run bandit
+        run: bandit -r .
 
       - name: Run CLI
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,8 @@ repos:
   rev: 3.7.9
   hooks:
     - id: flake8
+- repo: https://github.com/PyCQA/bandit
+  rev: 1.6.2
+  hooks:
+    - id: bandit
+      exclude: (^.tox/|^test/) # exclude .tox and test repo, keep in sync with .bandit file

--- a/doc/development.adoc
+++ b/doc/development.adoc
@@ -43,12 +43,12 @@ To uninstall, run:
 
     $ pip uninstall yubikey-manager
 
-=== Code Style
+=== Code Style & Security
 
-This project uses http://flake8.pycqa.org/[Flake8] for code style with a http://pre-commit.com/[pre-commit] hook.
+This project uses https://flake8.pycqa.org/[Flake8] for code style and https://github.com/PyCQA[Bandit] for security linting. These are invoked with a http://pre-commit.com/[pre-commit] hook.
 To use these:
 
-    $ pip install pre-commit flake8
+    $ pip install pre-commit flake8 bandit
     $ pre-commit install
 
 === Unit tests

--- a/ykman/cli/util.py
+++ b/ykman/cli/util.py
@@ -43,7 +43,8 @@ class UpperCaseChoice(click.Choice):
     """
     def __init__(self, choices):
         for v in choices:
-            assert v.upper() == v, 'Choice not all uppercase: ' + v
+            if v.upper() != v:
+                raise ValueError('Choice not all uppercase: ' + v)
         click.Choice.__init__(self, choices)
 
     def convert(self, value, param, ctx):

--- a/ykman/driver_ccid.py
+++ b/ykman/driver_ccid.py
@@ -300,14 +300,10 @@ def kill_scdaemon():
                 killed = True
     except ImportError:
         # Works for Linux and OS X.
-        pids = subprocess.check_output(  # nosec
-            "ps ax | grep scdaemon | grep -v grep | awk '{ print $1 }'",
-            shell=True).strip()
-        if pids:
-            for pid in pids.split():
-                subprocess.call(['kill', '-9', pid])  # nosec
+        return_code = subprocess.call(  # nosec
+            ['/usr/bin/pkill', '-9', 'scdaemon'])
+        if return_code == 0:
             killed = True
-
     if killed:
         time.sleep(0.1)
     return killed

--- a/ykman/driver_ccid.py
+++ b/ykman/driver_ccid.py
@@ -29,7 +29,7 @@ from __future__ import absolute_import
 
 import logging
 import struct
-import subprocess
+import subprocess  # nosec
 import time
 import six
 from enum import IntEnum, unique
@@ -300,12 +300,12 @@ def kill_scdaemon():
                 killed = True
     except ImportError:
         # Works for Linux and OS X.
-        pids = subprocess.check_output(
+        pids = subprocess.check_output(  # nosec
             "ps ax | grep scdaemon | grep -v grep | awk '{ print $1 }'",
             shell=True).strip()
         if pids:
             for pid in pids.split():
-                subprocess.call(['kill', '-9', pid])
+                subprocess.call(['kill', '-9', pid])  # nosec
             killed = True
 
     if killed:

--- a/ykman/oath.py
+++ b/ykman/oath.py
@@ -193,7 +193,7 @@ class Credential(object):
 
 
 def _derive_key(salt, passphrase):
-    kdf = PBKDF2HMAC(hashes.SHA1(), 16, salt, 1000, default_backend())
+    kdf = PBKDF2HMAC(hashes.SHA1(), 16, salt, 1000, default_backend())  # nosec
     return kdf.derive(passphrase.encode('utf-8'))
 
 
@@ -374,7 +374,7 @@ class OathController(object):
         key = self.derive_key(password)
         keydata = bytearray([OATH_TYPE.TOTP | ALGO.SHA1]) + key
         challenge = os.urandom(8)
-        h = hmac.HMAC(key, hashes.SHA1(), default_backend())
+        h = hmac.HMAC(key, hashes.SHA1(), default_backend())  # nosec
         h.update(challenge)
         response = h.finalize()
         data = Tlv(TAG.KEY, keydata) + Tlv(TAG.CHALLENGE, challenge) + Tlv(
@@ -386,11 +386,11 @@ class OathController(object):
         self.send_apdu(INS.SET_CODE, 0, 0, Tlv(TAG.KEY, b''))
 
     def validate(self, key):
-        h = hmac.HMAC(key, hashes.SHA1(), default_backend())
+        h = hmac.HMAC(key, hashes.SHA1(), default_backend())  # nosec
         h.update(self._challenge)
         response = h.finalize()
         challenge = os.urandom(8)
-        h = hmac.HMAC(key, hashes.SHA1(), default_backend())
+        h = hmac.HMAC(key, hashes.SHA1(), default_backend())  # nosec
         h.update(challenge)
         verification = h.finalize()
         data = Tlv(TAG.RESPONSE, response) + Tlv(TAG.CHALLENGE, challenge)

--- a/ykman/opgp.py
+++ b/ykman/opgp.py
@@ -256,7 +256,6 @@ class Kdf(object):
     def __init__(self, data):
         for field_tag, (field_name, field_type) in self._fields.items():
             tag, size = struct.unpack('cB', data[:2])
-            assert tag == field_tag
             setattr(self, field_name, field_type(data[2:2+size]))
             data = data[2+size:]
 

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -86,9 +86,9 @@ class PrepareUploadError(Enum):
     PUBLIC_ID_NOT_VV = 'Public ID must begin with "vv".'
     PUBLIC_ID_OCCUPIED = 'Public ID is already in use.'
     PUBLIC_ID_UNDEFINED = 'Public ID is required.'
-    SECRET_KEY_INVALID_LENGTH = 'Secret key must be 32 character long.'
-    SECRET_KEY_NOT_HEX = 'Secret key must consist only of hex characters (0-9A-F).'  # noqa: E501
-    SECRET_KEY_UNDEFINED = 'Secret key is required.'
+    SECRET_KEY_INVALID_LENGTH = 'Secret key must be 32 character long.'  # nosec
+    SECRET_KEY_NOT_HEX = 'Secret key must consist only of hex characters (0-9A-F).'  # noqa: E501 # nosec
+    SECRET_KEY_UNDEFINED = 'Secret key is required.'  # nosec
     SERIAL_NOT_INT = 'Serial number must be an integer.'
     SERIAL_TOO_LONG = 'Serial number is too long.'
 
@@ -230,7 +230,8 @@ class OtpController(object):
             'private_id': b2a_hex(private_id).decode('utf-8'),
         }
 
-        httpconn = http_client.HTTPSConnection(UPLOAD_HOST, timeout=1)
+        httpconn = http_client.HTTPSConnection(UPLOAD_HOST, timeout=1)  # nosec
+
         try:
             httpconn.request('POST', UPLOAD_PATH,
                              body=json.dumps(data, indent=False, sort_keys=True)

--- a/ykman/piv.py
+++ b/ykman/piv.py
@@ -332,7 +332,7 @@ def _get_key_data(key):
 
 def _dummy_key(algorithm):
     if algorithm == ALGO.RSA1024:
-        return rsa.generate_private_key(65537, 1024, default_backend())
+        return rsa.generate_private_key(65537, 1024, default_backend())  # nosec
     if algorithm == ALGO.RSA2048:
         return rsa.generate_private_key(65537, 2048, default_backend())
     if algorithm == ALGO.ECCP256:
@@ -370,7 +370,7 @@ _decrypt_len_conditions = {
 
 
 def _derive_key(pin, salt):
-    kdf = PBKDF2HMAC(hashes.SHA1(), 24, salt, 10000, default_backend())
+    kdf = PBKDF2HMAC(hashes.SHA1(), 24, salt, 10000, default_backend())  # nosec
     return kdf.derive(pin.encode('utf-8'))
 
 
@@ -621,7 +621,7 @@ class PivController(object):
         except ValueError:
             raise BadFormat('Management key must be exactly 24 bytes long, '
                             'was: {}'.format(len(key)), None)
-        cipher = Cipher(cipher_key, modes.ECB(), backend)
+        cipher = Cipher(cipher_key, modes.ECB(), backend)  # nosec
         decryptor = cipher.decryptor()
         pt1 = decryptor.update(ct1) + decryptor.finalize()
         ct2 = os.urandom(8)

--- a/ykman/util.py
+++ b/ykman/util.py
@@ -477,7 +477,6 @@ def parse_private_key(data, password):
             raise
         except Exception as e:
             logger.debug('Failed to parse PEM private key ', exc_info=e)
-            pass
 
     # PKCS12
     if is_pkcs12(data):
@@ -496,7 +495,6 @@ def parse_private_key(data, password):
             data, password, backend=default_backend())
     except Exception as e:
         logger.debug('Failed to parse private key as DER', exc_info=e)
-        pass
 
     # All parsing failed
     raise ValueError('Could not parse private key.')
@@ -517,7 +515,6 @@ def parse_certificates(data, password):
                         PEM_IDENTIFIER + cert, default_backend()))
             except Exception as e:
                 logger.debug('Failed to parse PEM certificate', exc_info=e)
-                pass
         # Could be valid PEM but not certificates.
         if len(certs) > 0:
             return certs
@@ -537,7 +534,6 @@ def parse_certificates(data, password):
         return [x509.load_der_x509_certificate(data, default_backend())]
     except Exception as e:
         logger.debug('Failed to parse certificate as DER', exc_info=e)
-        pass
 
     raise ValueError('Could not parse certificate.')
 

--- a/ykman/util.py
+++ b/ykman/util.py
@@ -426,7 +426,7 @@ def parse_truncated(resp):
 
 def hmac_shorten_key(key, algo):
     if algo.upper() == 'SHA1':
-        h = hashes.SHA1()
+        h = hashes.SHA1()  # nosec
     elif algo.upper() == 'SHA256':
         h = hashes.SHA256()
     elif algo.upper() == 'SHA512':

--- a/ykman/util.py
+++ b/ykman/util.py
@@ -475,7 +475,8 @@ def parse_private_key(data, password):
         except ValueError:
             # Cryptography raises ValueError if decryption fails.
             raise
-        except Exception:
+        except Exception as e:
+            logger.debug('Failed to parse PEM private key ', exc_info=e)
             pass
 
     # PKCS12
@@ -493,7 +494,8 @@ def parse_private_key(data, password):
     try:
         return serialization.load_der_private_key(
             data, password, backend=default_backend())
-    except Exception:
+    except Exception as e:
+        logger.debug('Failed to parse private key as DER', exc_info=e)
         pass
 
     # All parsing failed
@@ -513,7 +515,8 @@ def parse_certificates(data, password):
                 certs.append(
                     x509.load_pem_x509_certificate(
                         PEM_IDENTIFIER + cert, default_backend()))
-            except Exception:
+            except Exception as e:
+                logger.debug('Failed to parse PEM certificate', exc_info=e)
                 pass
         # Could be valid PEM but not certificates.
         if len(certs) > 0:
@@ -532,7 +535,8 @@ def parse_certificates(data, password):
     # DER
     try:
         return [x509.load_der_x509_certificate(data, default_backend())]
-    except Exception:
+    except Exception as e:
+        logger.debug('Failed to parse certificate as DER', exc_info=e)
         pass
 
     raise ValueError('Could not parse certificate.')


### PR DESCRIPTION
This adds [Bandit](https://github.com/PyCQA/bandit) integration as a pre-commit hook, which also runs on GitHub actions.

It also either fixes or suppresses some of the warnings:
- Add logging to empty Exception blocks
- Suppress warnings for use of SHA1 in a HMAC contexts
- Suppress warning for use of ECB in relation to the PIV management key
- Drop one use of assert, convert one use of assert to a regular check
- Suppress warning for use of subprocess module, HTTPSConnection, the word "secret" in some constants

To run bandit manually:

`$ bandit -r .`

Note that exclude directories are defined in the `.bandit` config file as well as in the pre-commit config.

I opted for suppressing warnings directly in the code with the `# nosec` syntax, since we already do that for flake8 exceptions and it provides an opportunity to explain why something is suppressed as well.