### PR TITLE
Improve type-checking for imported keys.

### DIFF
--- a/ykman/cli/piv.py
+++ b/ykman/cli/piv.py
@@ -410,11 +410,14 @@ def import_key(
     _check_touch_policy(ctx, controller, touch_policy)
     _check_key_size(ctx, controller, private_key)
 
-    controller.import_key(
+    try:
+        controller.import_key(
             slot,
             private_key,
             pin_policy,
             touch_policy)
+    except UnsupportedAlgorithm as e:
+        ctx.fail('Cannot import key: {}'.format(str(e)))
 
 
 @piv.command()
@@ -979,7 +982,8 @@ def _authenticate(ctx, controller, management_key, mgm_key_prompt,
 
 
 def _check_key_size(ctx, controller, private_key):
-    if (private_key.key_size == 1024
+    if (hasattr(private_key, 'key_size')
+            and private_key.key_size == 1024
             and ALGO.RSA1024 not in controller.supported_algorithms):
         ctx.fail('1024 is not a supported key size on this YubiKey.')
 


### PR DESCRIPTION
This PR adds reasonable output for cases like those seen in [issue #361](https://github.com/Yubico/yubikey-manager/issues/361).

I modified `_check_key_size()` to only verify key size if applicable, and then added additional checking for the call to `controller.import_key()` — which will throw an exception when a certain key/algorithm is not supported. A similar try/except already exists in `generate_key()`'s call to `controller.generate_key()`, but I couldn't find a reason it shouldn't exist here as well.