### PR TITLE
XDG Basedir compliance

### DIFF
--- a/ykman/settings.py
+++ b/ykman/settings.py
@@ -29,13 +29,26 @@ import os
 import json
 
 
-DIR_NAME = ".ykman"
+CONFIG_DIR_CANDIDATES = (
+    "./.ykman",
+    "~/.ykman",
+    "{}/ykman".format(os.environ.get("XDG_CONFIG_HOME", "~/.config")),
+)
 
 
 def _get_conf_dir():
-    if os.path.isdir(DIR_NAME):
-        return os.path.abspath(DIR_NAME)
-    return os.path.join(os.path.expanduser("~"), DIR_NAME)
+    """
+    gets directory to be used for configuration.
+
+    It returns first candidate, for which path exists and is a directory. If none of
+    candidates exists, it returns the last one, as this should be the preferred
+    location to save the new configuration files.
+    """
+    for path in CONFIG_DIR_CANDIDATES:
+        path = os.path.expanduser(os.path.abspath(path))
+        if os.path.isdir(path):
+            return path
+    return os.path.expanduser(os.path.abspath(CONFIG_DIR_CANDIDATES[-1]))
 
 
 class Settings(dict):

--- a/ykman/settings.py
+++ b/ykman/settings.py
@@ -62,7 +62,7 @@ class Settings(dict):
         return other is not None and self.fname == other.fname
 
     def __ne__(self, other):
-        return other is not None or self.fname != other.fname
+        return other is None or self.fname != other.fname
 
     def write(self):
         conf_dir = os.path.dirname(self.fname)

--- a/ykman/settings.py
+++ b/ykman/settings.py
@@ -68,8 +68,7 @@ class Settings(dict):
         conf_dir = os.path.dirname(self.fname)
         if not os.path.isdir(conf_dir):
             os.makedirs(conf_dir)
-        data = json.dumps(self, indent=2)
-        with open(self.fname, "w") as f:
-            f.write(data)
+        with self.fname.open("w") as fd:
+            json.dump(self, fd, indent=2)
 
     __hash__ = None


### PR DESCRIPTION
- Implemented XDG Basedir compliance
- Fixed `Settings` non-equality check
- Introduced `pathlib.Path` instead of `os.path` in loading settings file

Resolves #314 