### PR TITLE
Add FreeBSD install documentation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -89,6 +89,9 @@ above instead):
 ==== FreeBSD
 Althought not being officially supported on this platform, YubiKey Manager can be
 installed on FreeBSD. It's available via its ports tree or as pre-built package.
+Should you opt to install and use YubiKey Manager on this platform, please be aware
+that it's not mainly maintained by Yubico. A recommendation would be to first
+contact the FreeBSD port's maintainer to report any kind of issues.
 
 ==== Source
 To install from source, see the link:doc/Development.adoc[development]

--- a/README.adoc
+++ b/README.adoc
@@ -86,6 +86,10 @@ above instead):
   $ sudo apt update
   $ sudo apt install yubikey-manager
 
+==== FreeBSD
+Althought not being officially supported on this platform, YubiKey Manager can be
+installed on FreeBSD. It's available via its ports tree or as pre-built package.
+
 ==== Source
 To install from source, see the link:doc/Development.adoc[development]
 instructions.

--- a/README.adoc
+++ b/README.adoc
@@ -98,6 +98,9 @@ To install YubiKey Manager using the pre-built package on FreeBSD you need to ha
 
   $ sudo pkg install security/py-yubikey-manager
 
+If you wish to install it via ports tree, please refer to the official documentation
+on the https://docs.freebsd.org/en_US.ISO8859-1/books/handbook/ports-using.html[FreeBSD Handbook].
+
 ==== Source
 To install from source, see the link:doc/Development.adoc[development]
 instructions.

--- a/README.adoc
+++ b/README.adoc
@@ -90,17 +90,10 @@ above instead):
 Althought not being officially supported on this platform, YubiKey Manager can be
 installed on FreeBSD. It's available via its ports tree or as pre-built package.
 Should you opt to install and use YubiKey Manager on this platform, please be aware
-that it's not mainly maintained by Yubico. A recommendation would be to first
-contact the FreeBSD port's maintainer to report any kind of issues.
+that it's **NOT** maintained by Yubico.
 
-To install YubiKey Manager using the pre-built package on FreeBSD you need to have
-*root* privileges. Here we consider you can use `sudo` for that:
-
-  $ sudo pkg update -f
-  $ sudo pkg install security/py-yubikey-manager
-
-If you wish to install it via ports tree, please refer to the official documentation
-on the https://docs.freebsd.org/en_US.ISO8859-1/books/handbook/ports-using.html[FreeBSD Handbook].
+For more information about how to install packages or ports on FreeBSD, please refer
+to its official documentation: https://docs.freebsd.org/en/books/handbook/ports[FreeBSD Handbook].
 
 ==== Source
 To install from source, see the link:doc/Development.adoc[development]

--- a/README.adoc
+++ b/README.adoc
@@ -96,6 +96,7 @@ contact the FreeBSD port's maintainer to report any kind of issues.
 To install YubiKey Manager using the pre-built package on FreeBSD you need to have
 *root* privileges. Here we consider you can use `sudo` for that:
 
+  $ sudo pkg update -f
   $ sudo pkg install security/py-yubikey-manager
 
 If you wish to install it via ports tree, please refer to the official documentation

--- a/README.adoc
+++ b/README.adoc
@@ -93,6 +93,11 @@ Should you opt to install and use YubiKey Manager on this platform, please be aw
 that it's not mainly maintained by Yubico. A recommendation would be to first
 contact the FreeBSD port's maintainer to report any kind of issues.
 
+To install YubiKey Manager using the pre-built package on FreeBSD you need to have
+*root* privileges. Here we consider you can use `sudo` for that:
+
+  $ sudo pkg install security/py-yubikey-manager
+
 ==== Source
 To install from source, see the link:doc/Development.adoc[development]
 instructions.


### PR DESCRIPTION
by merging this request we would be able to:

  - share the information on how to install YubiKey Manager on FreeBSD;
  - take care of the decision made on https://github.com/Yubico/yubikey-manager/pull/139 by @dagheyman
    - inform that Yubico do **NOT** maintain any official package for this platform;
  - offer the easy option to install YubiKey Manager via `pkg`;
  - document and link the option to use the ports tree, but refer the official FreeBSD Handbook.

