### PR TITLE
Patch missing FreeBSD ykman/hid Backend support

### DIFF
--- a/ykman/hid/__init__.py
+++ b/ykman/hid/__init__.py
@@ -47,10 +47,12 @@ elif sys.platform.startswith("freebsd"):
 else:
     raise Exception("Unsupported platform")
 
+
 if backend is not None:
     list_otp_devices: Callable[[], List[OtpYubiKeyDevice]] = backend.list_devices
 else:
     list_otp_devices: Callable[[], List[OtpYubiKeyDevice]] = lambda: []
+
 
 class CtapYubiKeyDevice(YkmanDevice):
     """YubiKey FIDO USB HID device"""

--- a/ykman/hid/__init__.py
+++ b/ykman/hid/__init__.py
@@ -47,9 +47,10 @@ elif sys.platform.startswith("freebsd"):
 else:
     raise Exception("Unsupported platform")
 
-
-list_otp_devices: Callable[[], List[OtpYubiKeyDevice]] = backend.list_devices
-
+if backend is not None:
+    list_otp_devices: Callable[[], List[OtpYubiKeyDevice]] = backend.list_devices
+else:
+    list_otp_devices: Callable[[], List[OtpYubiKeyDevice]] = lambda: []
 
 class CtapYubiKeyDevice(YkmanDevice):
     """YubiKey FIDO USB HID device"""

--- a/ykman/hid/__init__.py
+++ b/ykman/hid/__init__.py
@@ -42,6 +42,8 @@ elif sys.platform.startswith("win32"):
     from . import windows as backend
 elif sys.platform.startswith("darwin"):
     from . import macos as backend
+elif sys.platform.startswith("freebsd"):
+    backend = None
 else:
     raise Exception("Unsupported platform")
 


### PR DESCRIPTION
by merging this request, we:

    - set 'backend' to be 'None' if we are on FreeBSD;
      - there's no official support for this platform;
    - avoid raising an exception on this special case;
    - replace `backend.list_devices` by `lambda: []` only for this platform;
    - make it possible to build, install and use YubiKey Manager on FreeBSD.

this patch was tested and suggested by FreeBSD developers (all credits to nwhitehorn@);
please refer to https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=254580 for more information.