### PR TITLE
Honor digits even for challenge

### DIFF
--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -591,8 +591,8 @@ def chalresp(ctx, slot, key, totp, touch, force, generate):
 @click.option(
     "-d",
     "--digits",
-    type=click.Choice(["6", "8"]),
-    default="6",
+    type=click.Choice(["0", "6", "8"]),
+    default="0",
     help="Number of digits in generated TOTP code (default: 6).",
 )
 @click.pass_context
@@ -633,7 +633,11 @@ def calculate(ctx, slot, challenge, totp, digits):
                 setattr(on_keepalive, "prompted", True)
 
         response = session.calculate_hmac_sha1(slot, challenge, event, on_keepalive)
-        if totp:
+
+        if totp and digits == '0':
+            digits = '6'
+
+        if digits != '0':            
             value = format_oath_code(response, int(digits))
         else:
             value = response.hex()


### PR DESCRIPTION
The ykchalresp tool will output a six or eight digit OTP code even if
challenge mode is chosen. This change does that for the ykman tool.

In order to know if the user has selected six or eight digits, I added
a zero selection to digits (although the text still says six). Later, if
TOTP mode is selected and digits is zero, we change the zero to six.

This way, behavior is the same when TOTP is selected, or no digit
count is specified.