### PR TITLE
oath: possible fix of duplicate options for period and password

### DIFF
--- a/ykman/cli/oath.py
+++ b/ykman/cli/oath.py
@@ -373,6 +373,7 @@ def accounts():
 )
 @click.option("-i", "--issuer", help="Issuer of the account.")
 @click.option(
+    "-P",
     "--period",
     help="Number of seconds a TOTP code is valid.",
     default=30,
@@ -523,7 +524,7 @@ def _add_cred(ctx, data, touch, force):
 @click_show_hidden_option
 @click.pass_context
 @click.option("-o", "--oath-type", is_flag=True, help="Display the OATH type.")
-@click.option("--period", is_flag=True, help="Display the period.")
+@click.option("-P", "--period", is_flag=True, help="Display the period.")
 @click_password_option
 @click_remember_option
 def list(ctx, show_hidden, oath_type, period, password, remember):

--- a/ykman/cli/oath.py
+++ b/ykman/cli/oath.py
@@ -373,7 +373,6 @@ def accounts():
 )
 @click.option("-i", "--issuer", help="Issuer of the account.")
 @click.option(
-    "-p",
     "--period",
     help="Number of seconds a TOTP code is valid.",
     default=30,
@@ -524,7 +523,7 @@ def _add_cred(ctx, data, touch, force):
 @click_show_hidden_option
 @click.pass_context
 @click.option("-o", "--oath-type", is_flag=True, help="Display the OATH type.")
-@click.option("-p", "--period", is_flag=True, help="Display the period.")
+@click.option("--period", is_flag=True, help="Display the period.")
 @click_password_option
 @click_remember_option
 def list(ctx, show_hidden, oath_type, period, password, remember):


### PR DESCRIPTION
Favors keeping `-p` for `--password` and using capital `-P` for `--period`. The change should not affect backwards compatibility, since using `-p` as `--period` was overshadowed by `--password` to begin with.

Fixes #427.

Edit: Capital short options