### PR TITLE
Use secrets module instead of urandom.

### DIFF
--- a/tests/device/cli/piv/test_read_write_object.py
+++ b/tests/device/cli/piv/test_read_write_object.py
@@ -1,4 +1,4 @@
-import os
+import secrets
 
 from cryptography.hazmat.primitives import serialization
 from ....util import generate_self_signed_certificate
@@ -44,7 +44,7 @@ class TestReadWriteObject:
         assert data == output_data
 
     def test_read_write_read_is_noop(self, ykman_cli):
-        data = os.urandom(32)
+        data = secrets.token_bytes(32)
 
         ykman_cli(
             "piv",
@@ -79,7 +79,7 @@ class TestReadWriteObject:
         assert output2 == data
 
     def test_read_write_aliases(self, ykman_cli):
-        data = os.urandom(32)
+        data = secrets.token_bytes(32)
 
         with io.StringIO() as buf:
             with contextlib.redirect_stderr(buf):

--- a/ykman/cli/config.py
+++ b/ykman/cli/config.py
@@ -42,7 +42,7 @@ from .util import (
     EnumChoice,
     cli_fail,
 )
-import os
+import secrets
 import re
 import click
 import logging
@@ -134,7 +134,7 @@ def set_lock_code(ctx, lock_code, new_lock_code, clear, generate, force):
     if clear:
         set_code = CLEAR_LOCK_CODE
     elif generate:
-        set_code = os.urandom(16)
+        set_code = secrets.token_bytes(16)
         click.echo(f"Using a randomly generated lock code: {set_code.hex()}")
         force or click.confirm(
             "Lock configuration with this lock code?", abort=True, err=True

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -71,7 +71,7 @@ from ..otp import (
 from threading import Event
 from time import time
 import logging
-import os
+import secrets
 import struct
 import click
 import webbrowser
@@ -391,7 +391,7 @@ def yubiotp(
 
     if not private_id:
         if generate_private_id:
-            private_id = os.urandom(6)
+            private_id = secrets.token_bytes(6)
             click.echo(f"Using a randomly generated private ID: {private_id.hex()}")
         elif force:
             ctx.fail(
@@ -404,7 +404,7 @@ def yubiotp(
 
     if not key:
         if generate_key:
-            key = os.urandom(16)
+            key = secrets.token_bytes(16)
             click.echo(f"Using a randomly generated secret key: {key.hex()}")
         elif force:
             ctx.fail(
@@ -565,7 +565,7 @@ def chalresp(ctx, slot, key, totp, touch, force, generate):
                 "set the KEY argument or set the --generate flag."
             )
         elif generate:
-            key = os.urandom(20)
+            key = secrets.token_bytes(20)
             if totp:
                 b32key = b32encode(key).decode()
                 click.echo(f"Using a randomly generated key (Base32): {b32key}")

--- a/ykman/piv.py
+++ b/ykman/piv.py
@@ -50,7 +50,7 @@ from collections import OrderedDict
 from datetime import datetime
 import logging
 import struct
-import os
+import secrets
 
 from typing import Union, Mapping, Optional, List, Type, cast
 
@@ -158,7 +158,7 @@ def derive_management_key(pin: str, salt: bytes) -> bytes:
 
 def generate_random_management_key(algorithm: MANAGEMENT_KEY_TYPE) -> bytes:
     """Generates a new random management key."""
-    return os.urandom(algorithm.key_len)
+    return secrets.token_bytes(algorithm.key_len)
 
 
 class PivmanData:
@@ -315,7 +315,7 @@ def pivman_change_pin(session: PivSession, old_pin: str, new_pin: str) -> None:
             derive_management_key(old_pin, cast(bytes, pivman.salt)),
         )
         session.verify_pin(new_pin)
-        new_salt = os.urandom(16)
+        new_salt = secrets.token_bytes(16)
         new_key = derive_management_key(new_pin, new_salt)
         session.set_management_key(MANAGEMENT_KEY_TYPE.TDES, new_key)
         pivman.salt = new_salt
@@ -395,7 +395,7 @@ def generate_chuid() -> bytes:
 
     return (
         Tlv(0x30, FASC_N)
-        + Tlv(0x34, os.urandom(16))
+        + Tlv(0x34, secrets.token_bytes(16))
         + Tlv(0x35, EXPIRY)
         + Tlv(0x3E)
         + Tlv(TAG_LRC)
@@ -405,7 +405,7 @@ def generate_chuid() -> bytes:
 def generate_ccc() -> bytes:
     """Generates a CCC (Card Capability Container)."""
     return (
-        Tlv(0xF0, b"\xa0\x00\x00\x01\x16\xff\x02" + os.urandom(14))
+        Tlv(0xF0, b"\xa0\x00\x00\x01\x16\xff\x02" + secrets.token_bytes(14))
         + Tlv(0xF1, b"\x21")
         + Tlv(0xF2, b"\x21")
         + Tlv(0xF3)

--- a/yubikit/oath.py
+++ b/yubikit/oath.py
@@ -20,7 +20,7 @@ from typing import Optional, List, Mapping
 import hmac
 import hashlib
 import struct
-import os
+import secrets
 import re
 
 
@@ -280,7 +280,7 @@ class OathSession:
 
     def validate(self, key: bytes) -> None:
         response = _hmac_sha1(key, self._challenge)
-        challenge = os.urandom(8)
+        challenge = secrets.token_bytes(8)
         data = Tlv(TAG_RESPONSE, response) + Tlv(TAG_CHALLENGE, challenge)
         resp = self.protocol.send_apdu(0, INS_VALIDATE, 0, 0, data)
         verification = _hmac_sha1(key, challenge)
@@ -291,7 +291,7 @@ class OathSession:
         self._challenge = None
 
     def set_key(self, key: bytes) -> None:
-        challenge = os.urandom(8)
+        challenge = secrets.token_bytes(8)
         response = _hmac_sha1(key, challenge)
         self.protocol.send_apdu(
             0,

--- a/yubikit/piv.py
+++ b/yubikit/piv.py
@@ -58,7 +58,7 @@ from enum import Enum, IntEnum, unique
 from typing import Optional, Union, Type, cast
 
 import logging
-import os
+import secrets
 import re
 
 
@@ -488,7 +488,7 @@ class PivSession:
             Tlv(TAG_DYN_AUTH, Tlv(TAG_AUTH_WITNESS)),
         )
         witness = Tlv.unpack(TAG_AUTH_WITNESS, Tlv.unpack(TAG_DYN_AUTH, response))
-        challenge = os.urandom(key_type.challenge_len)
+        challenge = secrets.token_bytes(key_type.challenge_len)
 
         backend = default_backend()
         cipher_key = _parse_management_key(key_type, management_key)


### PR DESCRIPTION
The old code used `os.urandom()` to generate random bytes. The new
source code uses `secrets.token_bytes()` instead. The secrets module is
preferred for cryptographic applications.