### PR TITLE
Improve description of cli chalresp KEY argument.

### DIFF
--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -532,7 +532,7 @@ def static(ctx, slot, password, generate, length, keyboard_layout, no_enter, for
     "--totp",
     is_flag=True,
     required=False,
-    help="Use a base32 encoded key for TOTP credentials.",
+    help="Use a base32 encoded key (optionally padded) for TOTP credentials.",
 )
 @click.option(
     "-g",
@@ -548,6 +548,9 @@ def chalresp(ctx, slot, key, totp, touch, force, generate):
     Program a challenge-response credential.
 
     If KEY is not given, an interactive prompt will ask for it.
+
+    \b
+    KEY     A key given in hex (or base32, if --totp is specified).
     """
     session = ctx.obj["session"]
 
@@ -568,9 +571,9 @@ def chalresp(ctx, slot, key, totp, touch, force, generate):
             key = os.urandom(20)
             if totp:
                 b32key = b32encode(key).decode()
-                click.echo(f"Using a randomly generated key (Base32): {b32key}")
+                click.echo(f"Using a randomly generated key (base32): {b32key}")
             else:
-                click.echo(f"Using a randomly generated key: {key.hex()}")
+                click.echo(f"Using a randomly generated key (hex): {key.hex()}")
         elif totp:
             while True:
                 key = click_prompt("Enter a secret key (base32)")

--- a/ykman/cli/util.py
+++ b/ykman/cli/util.py
@@ -28,6 +28,7 @@
 import functools
 import click
 import sys
+from typing import NoReturn
 from yubikit.core.otp import OtpConnection
 from yubikit.core.smartcard import SmartCardConnection
 from yubikit.core.fido import FidoConnection
@@ -224,6 +225,6 @@ def prompt_timeout(timeout=0.5):
         timer.cancel()
 
 
-def cli_fail(message: str, code: int = 1):
+def cli_fail(message: str, code: int = 1) -> NoReturn:
     click.echo(f"Error: {message}", err=True)
     sys.exit(code)

--- a/ykman/otp.py
+++ b/ykman/otp.py
@@ -34,7 +34,6 @@ from enum import Enum
 from http.client import HTTPSConnection
 from typing import Iterable
 
-import re
 import json
 import struct
 import random
@@ -166,11 +165,9 @@ def generate_static_pw(
 
 def parse_oath_key(val: str) -> bytes:
     """Parse a secret key encoded as either Hex or Base32."""
-    val = val.upper()
-    if re.match(r"^([0-9A-F]{2})+$", val):  # hex
+    try:
         return bytes.fromhex(val)
-    else:
-        # Key should be b32 encoded
+    except ValueError:
         return parse_b32_key(val)
 
 


### PR DESCRIPTION
When I used `ykman` I was confused about programming two yubikeys with
the same key in hmac-sha1: I didn't know if the key was read as a string
or in hex. I'm clarifying the description to explain that the key may be
either hex or base32. See also issue #482.