### PR TITLE
Refactor yubikit.support

### DIFF
--- a/tests/device/cli/piv/test_fips.py
+++ b/tests/device/cli/piv/test_fips.py
@@ -6,7 +6,7 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-@condition.fips(True)
+@condition.yk4_fips(True)
 @condition.capability(CAPABILITY.PIV)
 def ensure_piv(ykman_cli):
     ykman_cli("piv", "reset", "-f")

--- a/tests/device/cli/piv/test_generate_cert_and_csr.py
+++ b/tests/device/cli/piv/test_generate_cert_and_csr.py
@@ -80,7 +80,7 @@ class TestNonDefaultMgmKey:
         output = ykman_cli("piv", "info").output
         assert fingerprint in output
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     @condition.check(not_roca)
     def test_generate_self_signed_slot_9a_rsa1024(self, ykman_cli):
         self._test_generate_self_signed(ykman_cli, "9a", "RSA1024")
@@ -88,7 +88,7 @@ class TestNonDefaultMgmKey:
     def test_generate_self_signed_slot_9a_eccp256(self, ykman_cli):
         self._test_generate_self_signed(ykman_cli, "9a", "ECCP256")
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     @condition.check(not_roca)
     def test_generate_self_signed_slot_9c_rsa1024(self, ykman_cli):
         self._test_generate_self_signed(ykman_cli, "9c", "RSA1024")
@@ -96,7 +96,7 @@ class TestNonDefaultMgmKey:
     def test_generate_self_signed_slot_9c_eccp256(self, ykman_cli):
         self._test_generate_self_signed(ykman_cli, "9c", "ECCP256")
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     @condition.check(not_roca)
     def test_generate_self_signed_slot_9d_rsa1024(self, ykman_cli):
         self._test_generate_self_signed(ykman_cli, "9d", "RSA1024")
@@ -104,7 +104,7 @@ class TestNonDefaultMgmKey:
     def test_generate_self_signed_slot_9d_eccp256(self, ykman_cli):
         self._test_generate_self_signed(ykman_cli, "9d", "ECCP256")
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     @condition.check(not_roca)
     def test_generate_self_signed_slot_9e_rsa1024(self, ykman_cli):
         self._test_generate_self_signed(ykman_cli, "9e", "RSA1024")
@@ -145,7 +145,7 @@ class TestNonDefaultMgmKey:
 
         assert subject_input == subject_output
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     @condition.check(not_roca)
     def test_generate_csr_slot_9a_rsa1024(self, ykman_cli):
         self._test_generate_csr(ykman_cli, "9a", "RSA1024")
@@ -153,7 +153,7 @@ class TestNonDefaultMgmKey:
     def test_generate_csr_slot_9a_eccp256(self, ykman_cli):
         self._test_generate_csr(ykman_cli, "9a", "ECCP256")
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     @condition.check(not_roca)
     def test_generate_csr_slot_9c_rsa1024(self, ykman_cli):
         self._test_generate_csr(ykman_cli, "9c", "RSA1024")
@@ -161,7 +161,7 @@ class TestNonDefaultMgmKey:
     def test_generate_csr_slot_9c_eccp256(self, ykman_cli):
         self._test_generate_csr(ykman_cli, "9c", "ECCP256")
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     @condition.check(not_roca)
     def test_generate_csr_slot_9d_rsa1024(self, ykman_cli):
         self._test_generate_csr(ykman_cli, "9d", "RSA1024")
@@ -169,7 +169,7 @@ class TestNonDefaultMgmKey:
     def test_generate_csr_slot_9d_eccp256(self, ykman_cli):
         self._test_generate_csr(ykman_cli, "9d", "ECCP256")
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     @condition.check(not_roca)
     def test_generate_csr_slot_9e_rsa1024(self, ykman_cli):
         self._test_generate_csr(ykman_cli, "9e", "RSA1024")
@@ -216,7 +216,7 @@ class TestProtectedMgmKey:
         output = ykman_cli("piv", "info").output
         assert fingerprint in output
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     @condition.check(not_roca)
     def test_generate_self_signed_slot_9a_rsa1024(self, ykman_cli):
         self._test_generate_self_signed(ykman_cli, "9a", "RSA1024")
@@ -224,7 +224,7 @@ class TestProtectedMgmKey:
     def test_generate_self_signed_slot_9a_eccp256(self, ykman_cli):
         self._test_generate_self_signed(ykman_cli, "9a", "ECCP256")
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     @condition.check(not_roca)
     def test_generate_self_signed_slot_9c_rsa1024(self, ykman_cli):
         self._test_generate_self_signed(ykman_cli, "9c", "RSA1024")
@@ -232,7 +232,7 @@ class TestProtectedMgmKey:
     def test_generate_self_signed_slot_9c_eccp256(self, ykman_cli):
         self._test_generate_self_signed(ykman_cli, "9c", "ECCP256")
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     @condition.check(not_roca)
     def test_generate_self_signed_slot_9d_rsa1024(self, ykman_cli):
         self._test_generate_self_signed(ykman_cli, "9d", "RSA1024")
@@ -240,7 +240,7 @@ class TestProtectedMgmKey:
     def test_generate_self_signed_slot_9d_eccp256(self, ykman_cli):
         self._test_generate_self_signed(ykman_cli, "9d", "ECCP256")
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     @condition.check(not_roca)
     def test_generate_self_signed_slot_9e_rsa1024(self, ykman_cli):
         self._test_generate_self_signed(ykman_cli, "9e", "RSA1024")
@@ -273,7 +273,7 @@ class TestProtectedMgmKey:
 
         assert subject_input == subject_output
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     @condition.check(not_roca)
     def test_generate_csr_slot_9a_rsa1024(self, ykman_cli):
         self._test_generate_csr(ykman_cli, "9a", "RSA1024")
@@ -281,7 +281,7 @@ class TestProtectedMgmKey:
     def test_generate_csr_slot_9a_eccp256(self, ykman_cli):
         self._test_generate_csr(ykman_cli, "9a", "ECCP256")
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     @condition.check(not_roca)
     def test_generate_csr_slot_9c_rsa1024(self, ykman_cli):
         self._test_generate_csr(ykman_cli, "9c", "RSA1024")
@@ -289,7 +289,7 @@ class TestProtectedMgmKey:
     def test_generate_csr_slot_9c_eccp256(self, ykman_cli):
         self._test_generate_csr(ykman_cli, "9c", "ECCP256")
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     @condition.check(not_roca)
     def test_generate_csr_slot_9d_rsa1024(self, ykman_cli):
         self._test_generate_csr(ykman_cli, "9d", "RSA1024")
@@ -297,7 +297,7 @@ class TestProtectedMgmKey:
     def test_generate_csr_slot_9d_eccp256(self, ykman_cli):
         self._test_generate_csr(ykman_cli, "9d", "ECCP256")
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     @condition.check(not_roca)
     def test_generate_csr_slot_9e_rsa1024(self, ykman_cli):
         self._test_generate_csr(ykman_cli, "9e", "RSA1024")

--- a/tests/device/cli/piv/test_key_management.py
+++ b/tests/device/cli/piv/test_key_management.py
@@ -189,7 +189,7 @@ class TestKeyManagement:
             )
 
     @condition.check(not_roca)
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     def test_generate_key_rsa1024(self, ykman_cli):
         output = ykman_cli(
             "piv",
@@ -219,7 +219,7 @@ class TestKeyManagement:
         ).output
         assert "BEGIN PUBLIC KEY" in output
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     @condition.check(roca)
     def test_generate_key_rsa1024_cve201715361(self, ykman_cli):
         with pytest.raises(NotSupportedError):
@@ -400,7 +400,7 @@ class TestKeyManagement:
         csr = x509.load_pem_x509_csr(output.encode(), default_backend())
         assert csr.is_signature_valid
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     @condition.check(not_roca)
     def test_generate_csr_rsa1024(self, ykman_cli, tmp_file):
         self._test_generate_csr(ykman_cli, tmp_file, "RSA1024")

--- a/tests/device/cli/test_config.py
+++ b/tests/device/cli/test_config.py
@@ -1,6 +1,5 @@
-from yubikit.core import TRANSPORT
+from yubikit.core import TRANSPORT, YUBIKEY
 from yubikit.management import CAPABILITY
-from ykman.base import YUBIKEY
 from .. import condition
 
 import contextlib
@@ -23,7 +22,7 @@ def not_sky(device, info):
             and _fido_only(info.supported_capabilities[TRANSPORT.USB])
         )
     else:
-        return device.pid.get_type() != YUBIKEY.SKY
+        return device.pid.yubikey_type != YUBIKEY.SKY
 
 
 class TestConfigUSB:

--- a/tests/device/cli/test_misc.py
+++ b/tests/device/cli/test_misc.py
@@ -10,12 +10,12 @@ class TestYkmanInfo:
             assert "Serial number:" in output
         assert "Firmware version:" in output
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     def test_ykman_info_does_not_report_fips_for_non_fips_device(self, ykman_cli):
         with pytest.raises(SystemExit):
             ykman_cli("info", "--check-fips")
 
-    @condition.fips(True)
+    @condition.yk4_fips(True)
     def test_ykman_info_reports_fips_status(self, ykman_cli):
         info = ykman_cli("info", "--check-fips").output
         assert "FIPS Approved Mode:" in info

--- a/tests/device/cli/test_oath.py
+++ b/tests/device/cli/test_oath.py
@@ -46,7 +46,7 @@ class TestOATH:
         output = ykman_cli("oath", "info").output
         assert "version:" in output
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     def test_info_does_not_indicate_fips_mode_for_non_fips_key(self, ykman_cli):
         info = ykman_cli("oath", "info").output
         assert "FIPS:" not in info
@@ -230,7 +230,7 @@ class TestOATH:
         ykman_cli("oath", "accounts", "list")
         ykman_cli("oath", "accounts", "delete", "😃", "-f")
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     @condition.min_version(4, 3, 1)
     def test_oath_sha512(self, ykman_cli):
         ykman_cli("oath", "accounts", "add", "abba", "abba", "--algorithm", "SHA512")
@@ -262,7 +262,7 @@ class TestOATH:
 
 class TestOathFips:
     @pytest.fixture(autouse=True)
-    @condition.fips(True)
+    @condition.yk4_fips(True)
     def check_fips(self):
         pass
 

--- a/tests/device/cli/test_otp.py
+++ b/tests/device/cli/test_otp.py
@@ -56,7 +56,7 @@ class TestSlotStatus:
         output = ykman_cli("otp", "swap", "-f").output
         assert "Swapping slots..." in output
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     def test_ykman_otp_info_does_not_indicate_fips_mode_for_non_fips_key(
         self, ykman_cli
     ):  # noqa: E501
@@ -597,7 +597,7 @@ class TestSlotCalculate:
 
 class TestFipsMode:
     @pytest.fixture(autouse=True)
-    @condition.fips(True)
+    @condition.yk4_fips(True)
     def delete_slots(self, ykman_cli):
         try:
             ykman_cli("otp", "delete", "1", "-f")

--- a/tests/device/condition.py
+++ b/tests/device/condition.py
@@ -1,4 +1,4 @@
-from yubikit.support import is_fips_version
+from yubikit.support import is_yk4_fips_version
 from inspect import signature, Parameter, isgeneratorfunction
 from makefun import wraps
 
@@ -80,6 +80,6 @@ def max_version(major, minor=0, micro=0):
 
 def fips(status=True):
     return check(
-        lambda version: status == is_fips_version(version),
+        lambda version: status == is_yk4_fips_version(version),
         f"Requires FIPS = {status}",
     )

--- a/tests/device/condition.py
+++ b/tests/device/condition.py
@@ -1,4 +1,3 @@
-from yubikit.support import is_yk4_fips_version
 from inspect import signature, Parameter, isgeneratorfunction
 from makefun import wraps
 
@@ -78,8 +77,8 @@ def max_version(major, minor=0, micro=0):
     return check(lambda version: version <= vers, f"Version > {vers}")
 
 
-def fips(status=True):
+def yk4_fips(status=True):
     return check(
-        lambda version: status == is_yk4_fips_version(version),
-        f"Requires FIPS = {status}",
+        lambda info: status == (info.is_fips and info.version[0] == 4),
+        f"Requires YK4 FIPS = {status}",
     )

--- a/tests/device/condition.py
+++ b/tests/device/condition.py
@@ -1,4 +1,4 @@
-from ykman.device import is_fips_version
+from yubikit.support import is_fips_version
 from inspect import signature, Parameter, isgeneratorfunction
 from makefun import wraps
 

--- a/tests/device/conftest.py
+++ b/tests/device/conftest.py
@@ -4,7 +4,6 @@ from yubikit.core import TRANSPORT
 from yubikit.core.otp import OtpConnection
 from yubikit.core.fido import FidoConnection
 from yubikit.core.smartcard import SmartCardConnection
-from yubikit.management import USB_INTERFACE
 from functools import partial
 from . import condition
 
@@ -78,7 +77,7 @@ connection_scope = os.environ.get("CONNECTION_SCOPE", "function")
 @pytest.fixture(scope=connection_scope)
 @condition.transport(TRANSPORT.USB)
 def otp_connection(device, info):
-    if USB_INTERFACE.OTP in device.pid.usb_interfaces:
+    if device.pid.supports_connection(OtpConnection):
         with connect_to_device(info.serial, [OtpConnection])[0] as c:
             yield c
 
@@ -86,7 +85,7 @@ def otp_connection(device, info):
 @pytest.fixture(scope=connection_scope)
 @condition.transport(TRANSPORT.USB)
 def fido_connection(device, info):
-    if USB_INTERFACE.FIDO in device.pid.usb_interfaces:
+    if device.pid.supports_connection(FidoConnection):
         with connect_to_device(info.serial, [FidoConnection])[0] as c:
             yield c
 
@@ -96,7 +95,7 @@ def ccid_connection(device, info):
     if device.transport == TRANSPORT.NFC:
         with device.open_connection(SmartCardConnection) as c:
             yield c
-    elif USB_INTERFACE.CCID in device.pid.usb_interfaces:
+    if device.pid.supports_connection(SmartCardConnection):
         with connect_to_device(info.serial, [SmartCardConnection])[0] as c:
             yield c
     else:

--- a/tests/device/conftest.py
+++ b/tests/device/conftest.py
@@ -29,7 +29,7 @@ def _device(pytestconfig):
             pytest.exit("No/Multiple readers matched")
         dev = readers[0]
         with dev.open_connection(SmartCardConnection) as conn:
-            info = read_info(None, conn)
+            info = read_info(conn)
     else:
         devices = list_all_devices()
         if len(devices) != 1:

--- a/tests/device/conftest.py
+++ b/tests/device/conftest.py
@@ -78,7 +78,7 @@ connection_scope = os.environ.get("CONNECTION_SCOPE", "function")
 @pytest.fixture(scope=connection_scope)
 @condition.transport(TRANSPORT.USB)
 def otp_connection(device, info):
-    if USB_INTERFACE.OTP in device.pid.get_interfaces():
+    if USB_INTERFACE.OTP in device.pid.usb_interfaces:
         with connect_to_device(info.serial, [OtpConnection])[0] as c:
             yield c
 
@@ -86,7 +86,7 @@ def otp_connection(device, info):
 @pytest.fixture(scope=connection_scope)
 @condition.transport(TRANSPORT.USB)
 def fido_connection(device, info):
-    if USB_INTERFACE.FIDO in device.pid.get_interfaces():
+    if USB_INTERFACE.FIDO in device.pid.usb_interfaces:
         with connect_to_device(info.serial, [FidoConnection])[0] as c:
             yield c
 
@@ -96,7 +96,7 @@ def ccid_connection(device, info):
     if device.transport == TRANSPORT.NFC:
         with device.open_connection(SmartCardConnection) as c:
             yield c
-    elif USB_INTERFACE.CCID in device.pid.get_interfaces():
+    elif USB_INTERFACE.CCID in device.pid.usb_interfaces:
         with connect_to_device(info.serial, [SmartCardConnection])[0] as c:
             yield c
     else:

--- a/tests/device/test_fips_u2f_commands.py
+++ b/tests/device/test_fips_u2f_commands.py
@@ -9,7 +9,7 @@ import pytest
 
 
 @pytest.fixture(autouse=True)
-@condition.fips(True)
+@condition.yk4_fips(True)
 @condition.capability(CAPABILITY.U2F)
 @condition.transport(TRANSPORT.USB)
 def preconditions():

--- a/tests/device/test_interfaces.py
+++ b/tests/device/test_interfaces.py
@@ -14,7 +14,7 @@ def try_connection(conn_type):
 
 @condition.transport(TRANSPORT.USB)
 def test_switch_interfaces(pid):
-    interfaces = pid.get_interfaces()
+    interfaces = pid.usb_interfaces
     if USB_INTERFACE.FIDO in interfaces:
         assert try_connection(FidoConnection)
     if USB_INTERFACE.OTP in interfaces:

--- a/tests/device/test_interfaces.py
+++ b/tests/device/test_interfaces.py
@@ -3,7 +3,6 @@ from yubikit.core import TRANSPORT
 from yubikit.core.otp import OtpConnection
 from yubikit.core.fido import FidoConnection
 from yubikit.core.smartcard import SmartCardConnection
-from yubikit.management import USB_INTERFACE
 from . import condition
 
 
@@ -14,18 +13,17 @@ def try_connection(conn_type):
 
 @condition.transport(TRANSPORT.USB)
 def test_switch_interfaces(pid):
-    interfaces = pid.usb_interfaces
-    if USB_INTERFACE.FIDO in interfaces:
+    if pid.supports_connection(FidoConnection):
         assert try_connection(FidoConnection)
-    if USB_INTERFACE.OTP in interfaces:
+    if pid.supports_connection(OtpConnection):
         assert try_connection(OtpConnection)
-    if USB_INTERFACE.FIDO in interfaces:
+    if pid.supports_connection(FidoConnection):
         assert try_connection(FidoConnection)
-    if USB_INTERFACE.CCID in interfaces:
+    if pid.supports_connection(SmartCardConnection):
         assert try_connection(SmartCardConnection)
-    if USB_INTERFACE.OTP in interfaces:
+    if pid.supports_connection(OtpConnection):
         assert try_connection(OtpConnection)
-    if USB_INTERFACE.CCID in interfaces:
+    if pid.supports_connection(SmartCardConnection):
         assert try_connection(SmartCardConnection)
-    if USB_INTERFACE.FIDO in interfaces:
+    if pid.supports_connection(FidoConnection):
         assert try_connection(FidoConnection)

--- a/tests/device/test_oath.py
+++ b/tests/device/test_oath.py
@@ -1,7 +1,6 @@
 import pytest
 
-from yubikit.core import AID
-from yubikit.core.smartcard import ApduError, SW
+from yubikit.core.smartcard import ApduError, AID, SW
 from yubikit.management import CAPABILITY
 from yubikit.oath import (
     OathSession,
@@ -9,7 +8,7 @@ from yubikit.oath import (
     HASH_ALGORITHM,
     OATH_TYPE,
 )
-from ykman.device import is_fips_version
+from yubikit.support import is_fips_version
 from . import condition
 
 

--- a/tests/device/test_oath.py
+++ b/tests/device/test_oath.py
@@ -8,7 +8,7 @@ from yubikit.oath import (
     HASH_ALGORITHM,
     OATH_TYPE,
 )
-from yubikit.support import is_fips_version
+from yubikit.support import is_yk4_fips_version
 from . import condition
 
 
@@ -154,7 +154,7 @@ class TestHmacVectors:
     def test_vector(self, session, params):
         key, challenge, hash_algorithm, expected = params
         if hash_algorithm == HASH_ALGORITHM.SHA512:
-            if session.version < (4, 3, 1) or is_fips_version(session.version):
+            if session.version < (4, 3, 1) or is_yk4_fips_version(session.version):
                 pytest.skip("SHA512 requires (non-FIPS) YubiKey 4.3.1 or later")
         cred = session.put_credential(
             CredentialData("test", OATH_TYPE.TOTP, hash_algorithm, key)
@@ -198,7 +198,7 @@ class TestTotpVectors:
     def test_vector(self, session, params, digits):
         timestamp, hash_algorithm, value, key = params
         if hash_algorithm == HASH_ALGORITHM.SHA512:
-            if session.version < (4, 3, 1) or is_fips_version(session.version):
+            if session.version < (4, 3, 1) or is_yk4_fips_version(session.version):
                 pytest.skip("SHA512 requires (non-FIPS) YubiKey 4.3.1 or later")
 
         cred = session.put_credential(

--- a/tests/device/test_oath.py
+++ b/tests/device/test_oath.py
@@ -8,7 +8,6 @@ from yubikit.oath import (
     HASH_ALGORITHM,
     OATH_TYPE,
 )
-from yubikit.support import is_yk4_fips_version
 from . import condition
 
 
@@ -151,11 +150,12 @@ def _ids_hmac(params):
 
 class TestHmacVectors:
     @pytest.mark.parametrize("params", HMAC_PARAMS, ids=_ids_hmac)
-    def test_vector(self, session, params):
+    def test_vector(self, info, session, params):
         key, challenge, hash_algorithm, expected = params
         if hash_algorithm == HASH_ALGORITHM.SHA512:
-            if session.version < (4, 3, 1) or is_yk4_fips_version(session.version):
-                pytest.skip("SHA512 requires (non-FIPS) YubiKey 4.3.1 or later")
+            if info.version[0] == 4:
+                if info.is_fips or info.version < (4, 3, 1):
+                    pytest.skip("SHA512 requires (non-FIPS) YubiKey 4.3.1 or later")
         cred = session.put_credential(
             CredentialData("test", OATH_TYPE.TOTP, hash_algorithm, key)
         )
@@ -195,11 +195,12 @@ class TestTotpVectors:
     @pytest.mark.parametrize(
         "params", TOTP_PARAMS, ids=lambda x: "{1.name}-{0}".format(*x)
     )
-    def test_vector(self, session, params, digits):
+    def test_vector(self, info, session, params, digits):
         timestamp, hash_algorithm, value, key = params
         if hash_algorithm == HASH_ALGORITHM.SHA512:
-            if session.version < (4, 3, 1) or is_yk4_fips_version(session.version):
-                pytest.skip("SHA512 requires (non-FIPS) YubiKey 4.3.1 or later")
+            if info.version[0] == 4:
+                if info.is_fips or info.version < (4, 3, 1):
+                    pytest.skip("SHA512 requires (non-FIPS) YubiKey 4.3.1 or later")
 
         cred = session.put_credential(
             CredentialData("test", OATH_TYPE.TOTP, hash_algorithm, key, digits)

--- a/tests/device/test_openpgp.py
+++ b/tests/device/test_openpgp.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.serialization import Encoding, PublicFormat
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
@@ -31,6 +29,7 @@ def not_roca(version):
     return not ((4, 2, 0) <= version < (4, 3, 5))
 
 
+@condition.check(not_roca)
 def test_generate_requires_admin(controller):
     with pytest.raises(ApduError):
         controller.generate_rsa_key(KEY_SLOT.SIG, 2048)
@@ -46,6 +45,7 @@ def test_generate_rsa2048(controller):
 
 @condition.check(not_roca)
 @condition.min_version(4)
+@condition.yk4_fips(False)
 def test_generate_rsa4096(controller):
     controller.verify_admin(DEFAULT_ADMIN_PIN)
     pub = controller.generate_rsa_key(KEY_SLOT.SIG, 4096)
@@ -74,6 +74,12 @@ def test_generate_x25519(controller):
     assert len(pub.public_bytes(Encoding.Raw, PublicFormat.Raw)) == 32
 
 
+def test_import_requires_admin(controller):
+    priv = rsa.generate_private_key(E, 2048, default_backend())
+    with pytest.raises(ApduError):
+        controller.import_key(KEY_SLOT.SIG, priv)
+
+
 def test_import_rsa2048(controller):
     priv = rsa.generate_private_key(E, 2048, default_backend())
     controller.verify_admin(DEFAULT_ADMIN_PIN)
@@ -81,6 +87,7 @@ def test_import_rsa2048(controller):
 
 
 @condition.min_version(4)
+@condition.yk4_fips(False)
 def test_import_rsa4096(controller):
     priv = rsa.generate_private_key(E, 4096, default_backend())
     controller.verify_admin(DEFAULT_ADMIN_PIN)

--- a/tests/device/test_piv.py
+++ b/tests/device/test_piv.py
@@ -7,8 +7,8 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa, ec, padding
 
-from yubikit.core import AID, NotSupportedError
-from yubikit.core.smartcard import ApduError
+from yubikit.core import NotSupportedError
+from yubikit.core.smartcard import AID, ApduError
 from yubikit.management import CAPABILITY
 from yubikit.piv import (
     PivSession,
@@ -20,6 +20,7 @@ from yubikit.piv import (
     MANAGEMENT_KEY_TYPE,
     InvalidPinError,
 )
+from yubikit.support import is_fips_version
 from ykman.piv import (
     check_key,
     get_pivman_data,
@@ -29,7 +30,6 @@ from ykman.piv import (
     pivman_set_mgm_key,
 )
 from ykman.util import parse_certificates, parse_private_key
-from ykman.device import is_fips_version
 from ..util import open_file
 from . import condition
 

--- a/tests/device/test_piv.py
+++ b/tests/device/test_piv.py
@@ -20,7 +20,6 @@ from yubikit.piv import (
     MANAGEMENT_KEY_TYPE,
     InvalidPinError,
 )
-from yubikit.support import is_yk4_fips_version
 from ykman.piv import (
     check_key,
     get_pivman_data,
@@ -135,10 +134,12 @@ class TestCertificateSignatures:
     @pytest.mark.parametrize(
         "hash_algorithm", (hashes.SHA1, hashes.SHA256, hashes.SHA384, hashes.SHA512)
     )
-    def test_generate_self_signed_certificate(self, session, key_type, hash_algorithm):
+    def test_generate_self_signed_certificate(
+        self, info, session, key_type, hash_algorithm
+    ):
         if key_type == KEY_TYPE.ECCP384 and session.version < (4, 0, 0):
             pytest.skip("ECCP384 requires YubiKey 4 or later")
-        if key_type == KEY_TYPE.RSA1024 and is_yk4_fips_version(session.version):
+        if key_type == KEY_TYPE.RSA1024 and info.is_fips and info.version[0] == 4:
             pytest.skip("RSA1024 not available on YubiKey FIPS")
 
         slot = SLOT.SIGNATURE
@@ -248,7 +249,7 @@ class TestKeyManagement:
         assert not check_key(session, SLOT.AUTHENTICATION, cert.public_key())
 
     @condition.check(not_roca)
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     def test_put_certificate_verifies_key_pairing_rsa1024(self, session):
         self._test_put_key_pairing(session, KEY_TYPE.RSA1024, KEY_TYPE.ECCP256)
 
@@ -402,14 +403,14 @@ class TestOperations:
         sig = sign(session, SLOT.AUTHENTICATION, KEY_TYPE.ECCP256, b"foo")
         assert sig
 
-    @condition.fips(False)
+    @condition.yk4_fips(False)
     @condition.min_version(4)
     def test_sign_with_pin_policy_never_does_not_require_pin(self, session):
         generate_key(session, pin_policy=PIN_POLICY.NEVER)
         sig = sign(session, SLOT.AUTHENTICATION, KEY_TYPE.ECCP256, b"foo")
         assert sig
 
-    @condition.fips(True)
+    @condition.yk4_fips(True)
     def test_pin_policy_never_blocked_on_fips(self, session):
         with pytest.raises(NotSupportedError):
             generate_key(session, pin_policy=PIN_POLICY.NEVER)

--- a/tests/device/test_piv.py
+++ b/tests/device/test_piv.py
@@ -20,7 +20,7 @@ from yubikit.piv import (
     MANAGEMENT_KEY_TYPE,
     InvalidPinError,
 )
-from yubikit.support import is_fips_version
+from yubikit.support import is_yk4_fips_version
 from ykman.piv import (
     check_key,
     get_pivman_data,
@@ -138,7 +138,7 @@ class TestCertificateSignatures:
     def test_generate_self_signed_certificate(self, session, key_type, hash_algorithm):
         if key_type == KEY_TYPE.ECCP384 and session.version < (4, 0, 0):
             pytest.skip("ECCP384 requires YubiKey 4 or later")
-        if key_type == KEY_TYPE.RSA1024 and is_fips_version(session.version):
+        if key_type == KEY_TYPE.RSA1024 and is_yk4_fips_version(session.version):
             pytest.skip("RSA1024 not available on YubiKey FIPS")
 
         slot = SLOT.SIGNATURE

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -1,6 +1,4 @@
-from ykman.device import get_name
-from ykman.base import YUBIKEY
-from yubikit.core import TRANSPORT
+from yubikit.core import TRANSPORT, YUBIKEY
 from yubikit.management import (
     CAPABILITY,
     FORM_FACTOR,
@@ -8,6 +6,7 @@ from yubikit.management import (
     DeviceConfig,
     Version,
 )
+from yubikit.support import get_name
 from typing import cast
 
 

--- a/ykman/__init__.py
+++ b/ykman/__init__.py
@@ -25,13 +25,11 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .base import YUBIKEY, PID, YkmanDevice  # noqa
+from .base import YkmanDevice  # noqa
 from .device import (  # noqa
     scan_devices,
     list_all_devices,
     connect_to_device,
-    get_name,
-    read_info,
 )
 
 

--- a/ykman/__init__.py
+++ b/ykman/__init__.py
@@ -25,12 +25,4 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from .base import YkmanDevice  # noqa
-from .device import (  # noqa
-    scan_devices,
-    list_all_devices,
-    connect_to_device,
-)
-
-
 __version__ = "5.0.0-dev0"

--- a/ykman/base.py
+++ b/ykman/base.py
@@ -25,56 +25,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from yubikit.core import TRANSPORT, YubiKeyDevice
-from yubikit.management import USB_INTERFACE
-from enum import Enum, IntEnum, unique
+from yubikit.core import TRANSPORT, PID, YubiKeyDevice
 from typing import Optional, Hashable
-
-
-@unique
-class YUBIKEY(Enum):
-    """YubiKey hardware platforms."""
-
-    YKS = "YubiKey Standard"
-    NEO = "YubiKey NEO"
-    SKY = "Security Key by Yubico"
-    YKP = "YubiKey Plus"
-    YK4 = "YubiKey"  # This includes YubiKey 5
-
-    def get_pid(self, interfaces: USB_INTERFACE) -> "PID":
-        suffix = "_".join(
-            t.name or str(t) for t in USB_INTERFACE if t in USB_INTERFACE(interfaces)
-        )
-        return PID[self.name + "_" + suffix]
-
-
-@unique
-class PID(IntEnum):
-    """USB Product ID values for YubiKey devices."""
-
-    YKS_OTP = 0x0010
-    NEO_OTP = 0x0110
-    NEO_OTP_CCID = 0x0111
-    NEO_CCID = 0x0112
-    NEO_FIDO = 0x0113
-    NEO_OTP_FIDO = 0x0114
-    NEO_FIDO_CCID = 0x0115
-    NEO_OTP_FIDO_CCID = 0x0116
-    SKY_FIDO = 0x0120
-    YK4_OTP = 0x0401
-    YK4_FIDO = 0x0402
-    YK4_OTP_FIDO = 0x0403
-    YK4_CCID = 0x0404
-    YK4_OTP_CCID = 0x0405
-    YK4_FIDO_CCID = 0x0406
-    YK4_OTP_FIDO_CCID = 0x0407
-    YKP_OTP_FIDO = 0x0410
-
-    def get_type(self) -> YUBIKEY:
-        return YUBIKEY[self.name.split("_", 1)[0]]
-
-    def get_interfaces(self) -> USB_INTERFACE:
-        return USB_INTERFACE(sum(USB_INTERFACE[x] for x in self.name.split("_")[1:]))
 
 
 class YkmanDevice(YubiKeyDevice):

--- a/ykman/cli/__main__.py
+++ b/ykman/cli/__main__.py
@@ -25,7 +25,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from yubikit.core import USB_INTERFACE, ApplicationNotAvailableError
+from yubikit.core import ApplicationNotAvailableError
 from yubikit.core.otp import OtpConnection
 from yubikit.core.fido import FidoConnection
 from yubikit.core.smartcard import SmartCardConnection
@@ -67,13 +67,6 @@ logger = logging.getLogger(__name__)
 
 
 CLICK_CONTEXT_SETTINGS = dict(help_option_names=["-h", "--help"], max_content_width=999)
-
-
-USB_INTERFACE_MAPPING = {
-    SmartCardConnection: USB_INTERFACE.CCID,
-    OtpConnection: USB_INTERFACE.OTP,
-    FidoConnection: USB_INTERFACE.FIDO,
-}
 
 
 WIN_CTAP_RESTRICTED = (
@@ -190,7 +183,7 @@ def _run_cmd_for_single(ctx, cmd, connections, reader_name=None):
     # Only one connected device, check if any needed interfaces are available
     pid = next(iter(devices.keys()))
     for c in connections:
-        if USB_INTERFACE_MAPPING[c] & pid.usb_interfaces:
+        if pid.usb_interfaces.supports_connection(c):
             if WIN_CTAP_RESTRICTED and connections == FidoConnection:
                 # FIDO-only command on Windows without Admin won't work.
                 raise CliFail(

--- a/ykman/cli/__main__.py
+++ b/ykman/cli/__main__.py
@@ -183,7 +183,7 @@ def _run_cmd_for_single(ctx, cmd, connections, reader_name=None):
     # Only one connected device, check if any needed interfaces are available
     pid = next(iter(devices.keys()))
     for c in connections:
-        if pid.usb_interfaces.supports_connection(c):
+        if pid.supports_connection(c):
             if WIN_CTAP_RESTRICTED and connections == FidoConnection:
                 # FIDO-only command on Windows without Admin won't work.
                 raise CliFail(

--- a/ykman/cli/__main__.py
+++ b/ykman/cli/__main__.py
@@ -25,18 +25,16 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from yubikit.core import ApplicationNotAvailableError
+from yubikit.core import USB_INTERFACE, ApplicationNotAvailableError
 from yubikit.core.otp import OtpConnection
 from yubikit.core.fido import FidoConnection
 from yubikit.core.smartcard import SmartCardConnection
-from yubikit.management import USB_INTERFACE
+from yubikit.support import get_name, read_info
 from yubikit.logging import LOG_LEVEL
 
 from .. import __version__
 from ..pcsc import list_devices as list_ccid, list_readers
 from ..device import (
-    read_info,
-    get_name,
     list_all_devices,
     scan_devices,
     connect_to_device,
@@ -125,7 +123,7 @@ def print_diagnostics(ctx, param, value):
 
 
 def _disabled_interface(connections, cmd_name):
-    interfaces = [USB_INTERFACE_MAPPING[c] for c in connections]
+    interfaces = [c.usb_intrface for c in connections]
     req = ", ".join(t.name or str(t) for t in interfaces)
     raise CliFail(
         f"Command '{cmd_name}' requires one of the following USB interfaces "
@@ -192,7 +190,7 @@ def _run_cmd_for_single(ctx, cmd, connections, reader_name=None):
     # Only one connected device, check if any needed interfaces are available
     pid = next(iter(devices.keys()))
     for c in connections:
-        if USB_INTERFACE_MAPPING[c] & pid.get_interfaces():
+        if USB_INTERFACE_MAPPING[c] & pid.usb_interfaces:
             if WIN_CTAP_RESTRICTED and connections == FidoConnection:
                 # FIDO-only command on Windows without Admin won't work.
                 raise CliFail(
@@ -346,7 +344,7 @@ def list_keys(ctx, serials, readers):
         else:
             if dev.pid is None:  # Devices from list_all_devices should always have PID.
                 raise AssertionError("PID is None")
-            name = get_name(dev_info, dev.pid.get_type())
+            name = get_name(dev_info, dev.pid.yubikey_type)
             version = dev_info.version or "unknown"
             mode = dev.pid.name.split("_", 1)[1].replace("_", "+")
             click.echo(
@@ -361,7 +359,7 @@ def list_keys(ctx, serials, readers):
         for pid, count in devs.items():
             if pid not in pids:
                 for _ in range(count):
-                    name = pid.get_type().value
+                    name = pid.yubikey_type.value
                     mode = pid.name.split("_", 1)[1].replace("_", "+")
                     click.echo(f"{name} [{mode}] <access denied>")
 

--- a/ykman/cli/__main__.py
+++ b/ykman/cli/__main__.py
@@ -157,7 +157,7 @@ def _run_cmd_for_single(ctx, cmd, connections, reader_name=None):
                 dev = readers[0]
                 try:
                     conn = dev.open_connection(SmartCardConnection)
-                    info = read_info(dev.pid, conn)
+                    info = read_info(conn, dev.pid)
                     if cmd == fido.name:
                         conn.close()
                         conn = dev.open_connection(FidoConnection)

--- a/ykman/cli/__main__.py
+++ b/ykman/cli/__main__.py
@@ -123,7 +123,7 @@ def print_diagnostics(ctx, param, value):
 
 
 def _disabled_interface(connections, cmd_name):
-    interfaces = [c.usb_intrface for c in connections]
+    interfaces = [c.usb_interface for c in connections]
     req = ", ".join(t.name or str(t) for t in interfaces)
     raise CliFail(
         f"Command '{cmd_name}' requires one of the following USB interfaces "

--- a/ykman/cli/apdu.py
+++ b/ykman/cli/apdu.py
@@ -26,8 +26,13 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from binascii import a2b_hex
-from yubikit.core import AID
-from yubikit.core.smartcard import SmartCardConnection, SmartCardProtocol, ApduError, SW
+from yubikit.core.smartcard import (
+    SmartCardConnection,
+    SmartCardProtocol,
+    ApduError,
+    SW,
+    AID,
+)
 from .util import EnumChoice, ykman_command, CliFail
 from typing import Tuple, Optional
 

--- a/ykman/cli/config.py
+++ b/ykman/cli/config.py
@@ -25,7 +25,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from yubikit.core import TRANSPORT
+from yubikit.core import TRANSPORT, YUBIKEY
 from yubikit.management import (
     ManagementSession,
     DeviceConfig,
@@ -34,7 +34,6 @@ from yubikit.management import (
     DEVICE_FLAG,
     Mode,
 )
-from .. import YUBIKEY
 from .util import (
     click_postpone_execution,
     click_force_option,
@@ -207,9 +206,7 @@ def _configure_applications(
         if sum(CAPABILITY) & new_enabled == 0:
             ctx.fail(f"Can not disable all applications over {transport}.")
 
-        reboot = USB_INTERFACE.for_capabilities(
-            enabled
-        ) != USB_INTERFACE.for_capabilities(new_enabled)
+        reboot = enabled.usb_interfaces != new_enabled.usb_interfaces
     else:
         reboot = False
 
@@ -486,7 +483,7 @@ def _parse_mode_string(ctx, param, mode):
         if mode[0] in ["+", "-"]:
             info = ctx.obj["info"]
             usb_enabled = info.config.enabled_capabilities[TRANSPORT.USB]
-            interfaces = USB_INTERFACE.for_capabilities(usb_enabled)
+            interfaces = usb_enabled.usb_interfaces
             for mod in re.findall(r"[+-][A-Z]+", mode.upper()):
                 interface = _parse_interface_string(mod[1:])
                 if mod.startswith("+"):
@@ -557,12 +554,12 @@ def mode(ctx, mode, touch_eject, autoeject_timeout, chalresp_timeout, force):
     info = ctx.obj["info"]
     mgmt = ctx.obj["controller"]
     usb_enabled = info.config.enabled_capabilities[TRANSPORT.USB]
-    my_mode = Mode(USB_INTERFACE.for_capabilities(usb_enabled))
+    my_mode = Mode(usb_enabled.usb_interfaces)
     usb_supported = info.supported_capabilities[TRANSPORT.USB]
-    interfaces_supported = USB_INTERFACE.for_capabilities(usb_supported)
+    interfaces_supported = usb_supported.usb_interfaces
     pid = ctx.obj["pid"]
     if pid:
-        key_type = pid.get_type()
+        key_type = pid.yubikey_type
     else:
         key_type = None
 

--- a/ykman/cli/fido.py
+++ b/ykman/cli/fido.py
@@ -37,6 +37,7 @@ from fido2.ctap2 import (
 from fido2.pcsc import CtapPcscDevice
 from yubikit.core.fido import FidoConnection
 from yubikit.core.smartcard import SW
+from yubikit.support import is_fips_version
 from time import sleep
 from .util import (
     click_postpone_execution,
@@ -48,7 +49,6 @@ from .util import (
 from .util import CliFail
 from ..fido import is_in_fips_mode, fips_reset, fips_change_pin, fips_verify_pin
 from ..hid import list_ctap_devices
-from ..device import is_fips_version
 from ..pcsc import list_devices as list_ccid
 from smartcard.Exceptions import NoCardException, CardConnectionException
 from typing import Optional

--- a/ykman/cli/fido.py
+++ b/ykman/cli/fido.py
@@ -37,7 +37,6 @@ from fido2.ctap2 import (
 from fido2.pcsc import CtapPcscDevice
 from yubikit.core.fido import FidoConnection
 from yubikit.core.smartcard import SW
-from yubikit.support import is_yk4_fips_version
 from time import sleep
 from .util import (
     click_postpone_execution,
@@ -45,6 +44,7 @@ from .util import (
     click_force_option,
     ykman_group,
     prompt_timeout,
+    is_yk4_fips,
 )
 from .util import CliFail
 from ..fido import is_in_fips_mode, fips_reset, fips_change_pin, fips_verify_pin
@@ -97,7 +97,7 @@ def info(ctx):
     conn = ctx.obj["conn"]
     ctap2 = ctx.obj.get("ctap2")
 
-    if is_yk4_fips_version(ctx.obj["info"].version):
+    if is_yk4_fips(ctx.obj["info"]):
         click.echo("FIPS Approved Mode: " + ("Yes" if is_in_fips_mode(conn) else "No"))
     elif ctap2:
         client_pin = ClientPin(ctap2)  # N.B. All YubiKeys with CTAP2 support PIN.
@@ -196,7 +196,7 @@ def reset(ctx, force):
         n_keys = len(list_ctap_devices())
         if n_keys > 1:
             raise CliFail("Only one YubiKey can be connected to perform a reset.")
-        is_fips = is_yk4_fips_version(ctx.obj["info"].version)
+        is_fips = is_yk4_fips(ctx.obj["info"])
 
         ctap2 = ctx.obj.get("ctap2")
         if not is_fips and not ctap2:
@@ -305,7 +305,7 @@ def change_pin(ctx, pin, new_pin, u2f):
     6 characters long.
     """
 
-    is_fips = is_yk4_fips_version(ctx.obj["info"].version)
+    is_fips = is_yk4_fips(ctx.obj["info"])
 
     if is_fips and not u2f:
         raise CliFail(
@@ -435,7 +435,7 @@ def verify(ctx, pin):
             )
         except CtapError as e:
             raise CliFail(f"PIN verification failed: {e}")
-    elif is_yk4_fips_version(ctx.obj["info"].version):
+    elif is_yk4_fips(ctx.obj["info"]):
         _fail_if_not_valid_pin(ctx, pin, True)
         try:
             fips_verify_pin(ctx.obj["conn"], pin)

--- a/ykman/cli/fido.py
+++ b/ykman/cli/fido.py
@@ -37,7 +37,7 @@ from fido2.ctap2 import (
 from fido2.pcsc import CtapPcscDevice
 from yubikit.core.fido import FidoConnection
 from yubikit.core.smartcard import SW
-from yubikit.support import is_fips_version
+from yubikit.support import is_yk4_fips_version
 from time import sleep
 from .util import (
     click_postpone_execution,
@@ -97,7 +97,7 @@ def info(ctx):
     conn = ctx.obj["conn"]
     ctap2 = ctx.obj.get("ctap2")
 
-    if is_fips_version(ctx.obj["info"].version):
+    if is_yk4_fips_version(ctx.obj["info"].version):
         click.echo("FIPS Approved Mode: " + ("Yes" if is_in_fips_mode(conn) else "No"))
     elif ctap2:
         client_pin = ClientPin(ctap2)  # N.B. All YubiKeys with CTAP2 support PIN.
@@ -196,7 +196,7 @@ def reset(ctx, force):
         n_keys = len(list_ctap_devices())
         if n_keys > 1:
             raise CliFail("Only one YubiKey can be connected to perform a reset.")
-        is_fips = is_fips_version(ctx.obj["info"].version)
+        is_fips = is_yk4_fips_version(ctx.obj["info"].version)
 
         ctap2 = ctx.obj.get("ctap2")
         if not is_fips and not ctap2:
@@ -305,7 +305,7 @@ def change_pin(ctx, pin, new_pin, u2f):
     6 characters long.
     """
 
-    is_fips = is_fips_version(ctx.obj["info"].version)
+    is_fips = is_yk4_fips_version(ctx.obj["info"].version)
 
     if is_fips and not u2f:
         raise CliFail(
@@ -314,7 +314,7 @@ def change_pin(ctx, pin, new_pin, u2f):
 
     if u2f and not is_fips:
         raise CliFail(
-            "This is not a YubiKey FIPS, and therefore does not support a U2F PIN. "
+            "This is not a YubiKey 4 FIPS, and therefore does not support a U2F PIN. "
             "To set the FIDO2 PIN, remove the --u2f option."
         )
 
@@ -435,7 +435,7 @@ def verify(ctx, pin):
             )
         except CtapError as e:
             raise CliFail(f"PIN verification failed: {e}")
-    elif is_fips_version(ctx.obj["info"].version):
+    elif is_yk4_fips_version(ctx.obj["info"].version):
         _fail_if_not_valid_pin(ctx, pin, True)
         try:
             fips_verify_pin(ctx.obj["conn"], pin)

--- a/ykman/cli/info.py
+++ b/ykman/cli/info.py
@@ -32,7 +32,7 @@ from yubikit.core.smartcard import SmartCardConnection
 from yubikit.management import CAPABILITY, USB_INTERFACE
 from yubikit.yubiotp import YubiOtpSession
 from yubikit.oath import OathSession
-from yubikit.support import get_name, is_fips_version
+from yubikit.support import get_name, is_yk4_fips_version
 
 from .util import CliFail
 from ..device import connect_to_device
@@ -198,7 +198,7 @@ def info(ctx, check_fips):
     )
 
     if check_fips:
-        if is_fips_version(info.version):
+        if is_yk4_fips_version(info.version):
             ctx.obj["conn"].close()
             _check_fips_status(pid, info)
         else:

--- a/ykman/cli/info.py
+++ b/ykman/cli/info.py
@@ -32,9 +32,10 @@ from yubikit.core.smartcard import SmartCardConnection
 from yubikit.management import CAPABILITY, USB_INTERFACE
 from yubikit.yubiotp import YubiOtpSession
 from yubikit.oath import OathSession
+from yubikit.support import get_name, is_fips_version
 
 from .util import CliFail
-from ..device import is_fips_version, get_name, connect_to_device
+from ..device import connect_to_device
 from ..otp import is_in_fips_mode as otp_in_fips_mode
 from ..oath import is_in_fips_mode as oath_in_fips_mode
 from ..fido import is_in_fips_mode as ctap_in_fips_mode
@@ -159,8 +160,8 @@ def info(ctx, check_fips):
         interfaces = None
         key_type = None
     else:
-        interfaces = pid.get_interfaces()
-        key_type = pid.get_type()
+        interfaces = pid.usb_interfaces
+        key_type = pid.yubikey_type
     device_name = get_name(info, key_type)
 
     click.echo(f"Device type: {device_name}")

--- a/ykman/cli/info.py
+++ b/ykman/cli/info.py
@@ -32,9 +32,9 @@ from yubikit.core.smartcard import SmartCardConnection
 from yubikit.management import CAPABILITY, USB_INTERFACE
 from yubikit.yubiotp import YubiOtpSession
 from yubikit.oath import OathSession
-from yubikit.support import get_name, is_yk4_fips_version
+from yubikit.support import get_name
 
-from .util import CliFail
+from .util import CliFail, is_yk4_fips
 from ..device import connect_to_device
 from ..otp import is_in_fips_mode as otp_in_fips_mode
 from ..oath import is_in_fips_mode as oath_in_fips_mode
@@ -198,7 +198,7 @@ def info(ctx, check_fips):
     )
 
     if check_fips:
-        if is_yk4_fips_version(info.version):
+        if is_yk4_fips(info):
             ctx.obj["conn"].close()
             _check_fips_status(pid, info)
         else:

--- a/ykman/cli/oath.py
+++ b/ykman/cli/oath.py
@@ -38,6 +38,7 @@ from .util import (
     prompt_for_touch,
     prompt_timeout,
     EnumChoice,
+    is_yk4_fips,
 )
 from yubikit.core.smartcard import ApduError, SW, SmartCardConnection
 from yubikit.oath import (
@@ -48,7 +49,6 @@ from yubikit.oath import (
     parse_b32_key,
     _format_cred_id,
 )
-from yubikit.support import is_yk4_fips_version
 from ..oath import is_steam, calculate_steam, is_hidden
 from ..settings import AppData
 
@@ -98,7 +98,7 @@ def info(ctx):
     if session.locked and session.device_id in keys:
         click.echo("The password for this YubiKey is remembered by ykman.")
 
-    if is_yk4_fips_version(version):
+    if is_yk4_fips(ctx.obj["info"]):
         click.echo(f"FIPS Approved Mode: {'Yes' if session.locked else 'No'}")
 
 
@@ -530,7 +530,7 @@ def _add_cred(ctx, data, touch, force):
         ctx.fail("Counter only supported for HOTP accounts.")
 
     if data.hash_algorithm == HASH_ALGORITHM.SHA512 and (
-        version < (4, 3, 1) or is_yk4_fips_version(version)
+        version < (4, 3, 1) or is_yk4_fips(ctx.obj["info"])
     ):
         raise CliFail("Algorithm SHA512 not supported on this YubiKey.")
 

--- a/ykman/cli/oath.py
+++ b/ykman/cli/oath.py
@@ -48,8 +48,8 @@ from yubikit.oath import (
     parse_b32_key,
     _format_cred_id,
 )
+from yubikit.support import is_fips_version
 from ..oath import is_steam, calculate_steam, is_hidden
-from ..device import is_fips_version
 from ..settings import AppData
 
 

--- a/ykman/cli/oath.py
+++ b/ykman/cli/oath.py
@@ -48,7 +48,7 @@ from yubikit.oath import (
     parse_b32_key,
     _format_cred_id,
 )
-from yubikit.support import is_fips_version
+from yubikit.support import is_yk4_fips_version
 from ..oath import is_steam, calculate_steam, is_hidden
 from ..settings import AppData
 
@@ -98,7 +98,7 @@ def info(ctx):
     if session.locked and session.device_id in keys:
         click.echo("The password for this YubiKey is remembered by ykman.")
 
-    if is_fips_version(version):
+    if is_yk4_fips_version(version):
         click.echo(f"FIPS Approved Mode: {'Yes' if session.locked else 'No'}")
 
 
@@ -530,7 +530,7 @@ def _add_cred(ctx, data, touch, force):
         ctx.fail("Counter only supported for HOTP accounts.")
 
     if data.hash_algorithm == HASH_ALGORITHM.SHA512 and (
-        version < (4, 3, 1) or is_fips_version(version)
+        version < (4, 3, 1) or is_yk4_fips_version(version)
     ):
         raise CliFail("Algorithm SHA512 not supported on this YubiKey.")
 

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -43,7 +43,7 @@ from yubikit.core.otp import (
     modhex_decode,
     OtpConnection,
 )
-from yubikit.support import is_fips_version
+from yubikit.support import is_yk4_fips_version
 
 from .util import (
     ykman_group,
@@ -200,7 +200,7 @@ def info(ctx):
     click.echo(f"Slot 1: {slot1 and 'programmed' or 'empty'}")
     click.echo(f"Slot 2: {slot2 and 'programmed' or 'empty'}")
 
-    if is_fips_version(session.version):
+    if is_yk4_fips_version(session.version):
         click.echo(f"FIPS Approved Mode: {'Yes' if is_in_fips_mode(session) else 'No'}")
 
 

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -43,7 +43,6 @@ from yubikit.core.otp import (
     modhex_decode,
     OtpConnection,
 )
-from yubikit.support import is_yk4_fips_version
 
 from .util import (
     ykman_group,
@@ -55,6 +54,7 @@ from .util import (
     click_prompt,
     prompt_for_touch,
     EnumChoice,
+    is_yk4_fips,
 )
 from .. import __version__
 from ..scancodes import encode, KEYBOARD_LAYOUT
@@ -200,7 +200,7 @@ def info(ctx):
     click.echo(f"Slot 1: {slot1 and 'programmed' or 'empty'}")
     click.echo(f"Slot 2: {slot2 and 'programmed' or 'empty'}")
 
-    if is_yk4_fips_version(session.version):
+    if is_yk4_fips(ctx.obj["info"]):
         click.echo(f"FIPS Approved Mode: {'Yes' if is_in_fips_mode(session) else 'No'}")
 
 

--- a/ykman/cli/otp.py
+++ b/ykman/cli/otp.py
@@ -43,6 +43,7 @@ from yubikit.core.otp import (
     modhex_decode,
     OtpConnection,
 )
+from yubikit.support import is_fips_version
 
 from .util import (
     ykman_group,
@@ -56,7 +57,6 @@ from .util import (
     EnumChoice,
 )
 from .. import __version__
-from ..device import is_fips_version
 from ..scancodes import encode, KEYBOARD_LAYOUT
 from ..otp import (
     PrepareUploadFailed,

--- a/ykman/cli/util.py
+++ b/ykman/cli/util.py
@@ -31,6 +31,7 @@ import sys
 from yubikit.core.otp import OtpConnection
 from yubikit.core.smartcard import SmartCardConnection
 from yubikit.core.fido import FidoConnection
+from yubikit.management import DeviceInfo
 from yubikit.oath import parse_b32_key
 from collections import OrderedDict
 from collections.abc import MutableMapping
@@ -276,3 +277,7 @@ def pretty_print(value, level: int = 0) -> List[str]:
     else:
         lines.append(f"{indent}{value}")
     return lines
+
+
+def is_yk4_fips(info: DeviceInfo) -> bool:
+    return info.version[0] == 4 and info.is_fips

--- a/ykman/device.py
+++ b/ykman/device.py
@@ -25,7 +25,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from yubikit.core import Connection, TRANSPORT
+from yubikit.core import Connection, PID, TRANSPORT
 from yubikit.core.otp import OtpConnection
 from yubikit.core.fido import FidoConnection
 from yubikit.core.smartcard import SmartCardConnection
@@ -34,7 +34,7 @@ from yubikit.management import (
     USB_INTERFACE,
 )
 from yubikit.support import read_info
-from .base import PID, YkmanDevice
+from .base import YkmanDevice
 from .hid import (
     list_otp_devices as _list_otp_devices,
     list_ctap_devices as _list_ctap_devices,

--- a/ykman/device.py
+++ b/ykman/device.py
@@ -214,7 +214,7 @@ class _UsbCompositeDevice(YkmanDevice):
         self._key = key
 
     def supports_connection(self, connection_type):
-        return cast(PID, self.pid).usb_interfaces.supports_connection(connection_type)
+        return cast(PID, self.pid).supports_connection(connection_type)
 
     def open_connection(self, connection_type):
         if not self.supports_connection(connection_type):

--- a/ykman/device.py
+++ b/ykman/device.py
@@ -160,7 +160,7 @@ class _PidGroup:
         if len(self._resolved) < max(self._devcount.values()):
             try:
                 with dev.open_connection(conn_type) as conn:
-                    info = read_info(dev.pid, conn)
+                    info = read_info(conn, dev.pid)
                 key = self._key(info)
                 self._infos[key] = info
                 self._resolved.setdefault(key, {})[iface] = dev
@@ -182,7 +182,7 @@ class _PidGroup:
                 dev = devs.pop()
                 try:
                     conn = dev.open_connection(conn_type)
-                    info = read_info(dev.pid, conn)
+                    info = read_info(conn, dev.pid)
                     dev_key = self._key(info)
                     if dev_key in self._infos:
                         self._resolved.setdefault(dev_key, {})[iface] = dev
@@ -236,7 +236,6 @@ def list_all_devices() -> List[Tuple[YkmanDevice, DeviceInfo]]:
                 group.add(connection_type, dev)
         except Exception:
             logger.exception("Unable to list devices for connection")
-
     devices = []
     for group in groups.values():
         devices.extend(group.get_devices())
@@ -273,7 +272,7 @@ def connect_to_device(
                 retry_ccid.append(dev)
                 logger.debug("CCID No card present, will retry")
                 continue
-            info = read_info(dev.pid, conn)
+            info = read_info(conn, dev.pid)
             if serial and info.serial != serial:
                 conn.close()
             else:
@@ -293,7 +292,7 @@ def connect_to_device(
             except NoCardException:
                 continue
             retry_ccid.remove(dev)
-            info = read_info(dev.pid, conn)
+            info = read_info(conn, dev.pid)
             if serial and info.serial != serial:
                 conn.close()
             else:

--- a/ykman/device.py
+++ b/ykman/device.py
@@ -25,31 +25,16 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from yubikit.core import (
-    AID,
-    TRANSPORT,
-    Version,
-    Connection,
-    NotSupportedError,
-    ApplicationNotAvailableError,
-)
-from yubikit.core.otp import OtpConnection, CommandRejectedError
+from yubikit.core import Connection, TRANSPORT
+from yubikit.core.otp import OtpConnection
 from yubikit.core.fido import FidoConnection
-from yubikit.core.smartcard import (
-    SmartCardConnection,
-    SmartCardProtocol,
-)
+from yubikit.core.smartcard import SmartCardConnection
 from yubikit.management import (
-    ManagementSession,
     DeviceInfo,
-    DeviceConfig,
     USB_INTERFACE,
-    CAPABILITY,
-    FORM_FACTOR,
-    DEVICE_FLAG,
 )
-from yubikit.yubiotp import YubiOtpSession
-from .base import PID, YUBIKEY, YkmanDevice
+from yubikit.support import read_info
+from .base import PID, YkmanDevice
 from .hid import (
     list_otp_devices as _list_otp_devices,
     list_ctap_devices as _list_ctap_devices,
@@ -111,13 +96,6 @@ def list_otp_devices():
     return _list_otp_devices()
 
 
-def is_fips_version(version: Version) -> bool:
-    """True if a given firmware version indicates a YubiKey (4) FIPS"""
-    return (4, 4, 0) <= version < (4, 5, 0)
-
-
-BASE_NEO_APPS = CAPABILITY.OTP | CAPABILITY.OATH | CAPABILITY.PIV | CAPABILITY.OPENPGP
-
 CONNECTION_LIST_MAPPING = {
     SmartCardConnection: list_ccid_devices,
     OtpConnection: list_otp_devices,
@@ -156,10 +134,6 @@ def scan_devices() -> Tuple[Mapping[PID, int], int]:
     return merged, hash(tuple(fingerprints))
 
 
-def _usb_interface_for(connection_type):
-    return next(i for i in USB_INTERFACE if i.supports_connection(connection_type))
-
-
 class _PidGroup:
     def __init__(self):
         self._infos: Dict[Hashable, DeviceInfo] = {}
@@ -181,7 +155,7 @@ class _PidGroup:
 
     def add(self, conn_type, dev):
         logger.debug(f"Add device for {conn_type}: {dev}")
-        iface = _usb_interface_for(conn_type)
+        iface = conn_type.usb_interface
         self._devcount[iface] += 1
         if len(self._resolved) < max(self._devcount.values()):
             try:
@@ -197,7 +171,7 @@ class _PidGroup:
         self._unresolved.setdefault(iface, []).append(dev)
 
     def connect(self, key, conn_type):
-        iface = _usb_interface_for(conn_type)
+        iface = conn_type.usb_interface
         dev = self._resolved[key].get(iface)
         if dev:
             return dev.open_connection(conn_type)
@@ -240,7 +214,7 @@ class _UsbCompositeDevice(YkmanDevice):
         self._key = key
 
     def supports_connection(self, connection_type):
-        return cast(PID, self.pid).get_interfaces().supports_connection(connection_type)
+        return cast(PID, self.pid).usb_interfaces.supports_connection(connection_type)
 
     def open_connection(self, connection_type):
         if not self.supports_connection(connection_type):
@@ -328,360 +302,3 @@ def connect_to_device(
     if serial:
         raise ValueError("YubiKey with given serial not found")
     raise ValueError("No YubiKey found with the given interface(s)")
-
-
-def _otp_read_data(conn) -> Tuple[Version, Optional[int]]:
-    otp = YubiOtpSession(conn)
-    version = otp.version
-    serial: Optional[int] = None
-    try:
-        serial = otp.get_serial()
-    except Exception:
-        logger.debug("Unable to read serial over OTP, no serial", exc_info=True)
-    return version, serial
-
-
-AID_U2F_YUBICO = b"\xa0\x00\x00\x05\x27\x10\x02"  # Old U2F AID
-
-SCAN_APPLETS = {
-    # AID.OTP: CAPABILITY.OTP,  # NB: OTP will be checked elsewhere
-    AID.FIDO: CAPABILITY.U2F,
-    AID_U2F_YUBICO: CAPABILITY.U2F,
-    AID.PIV: CAPABILITY.PIV,
-    AID.OPENPGP: CAPABILITY.OPENPGP,
-    AID.OATH: CAPABILITY.OATH,
-}
-
-
-def _read_info_ccid(conn, key_type, interfaces):
-    version: Optional[Version] = None
-    try:
-        mgmt = ManagementSession(conn)
-        version = mgmt.version
-        try:
-            return mgmt.read_device_info()
-        except NotSupportedError:
-            # Workaround to "de-select" the Management Applet needed for NEO
-            conn.send_and_receive(b"\xa4\x04\x00\x08")
-    except ApplicationNotAvailableError:
-        logger.debug("Couldn't select Management application, use fallback")
-
-    # Synthesize data
-    capabilities = CAPABILITY(0)
-
-    # Try to read serial (and version if needed) from OTP application
-    try:
-        otp_version, serial = _otp_read_data(conn)
-        capabilities |= CAPABILITY.OTP
-        if version is None:
-            version = otp_version
-    except ApplicationNotAvailableError:
-        logger.debug("Couldn't select OTP application, serial unknown")
-        serial = None
-
-    if version is None:
-        logger.debug("Firmware version unknown, using 3.0.0 as a baseline")
-        version = Version(3, 0, 0)  # Guess, no way to know
-
-    # Scan for remaining capabilities
-    logger.debug("Scan for available applications...")
-    protocol = SmartCardProtocol(conn)
-    for aid, code in SCAN_APPLETS.items():
-        try:
-            protocol.select(aid)
-            capabilities |= code
-            logger.debug("Found applet: aid: %s, capability: %s", aid, code)
-        except ApplicationNotAvailableError:
-            logger.debug("Missing applet: aid: %s, capability: %s", aid, code)
-        except Exception:
-            logger.exception(
-                "Error selecting aid: %s, capability: %s",
-                aid,
-                code,
-            )
-
-    # Assume U2F on devices >= 3.3.0
-    if USB_INTERFACE.FIDO in interfaces or version >= (3, 3, 0):
-        capabilities |= CAPABILITY.U2F
-
-    return DeviceInfo(
-        config=DeviceConfig(
-            enabled_capabilities={},  # Populated later
-            auto_eject_timeout=0,
-            challenge_response_timeout=0,
-            device_flags=DEVICE_FLAG(0),
-        ),
-        serial=serial,
-        version=version,
-        form_factor=FORM_FACTOR.UNKNOWN,
-        supported_capabilities={
-            TRANSPORT.USB: capabilities,
-            TRANSPORT.NFC: capabilities,
-        },
-        is_locked=False,
-    )
-
-
-def _read_info_otp(conn, key_type, interfaces):
-    otp = None
-    serial = None
-
-    try:
-        mgmt = ManagementSession(conn)
-    except ApplicationNotAvailableError:
-        otp = YubiOtpSession(conn)
-
-    # Retry during potential reclaim timeout period (~3s).
-    for _ in range(8):
-        try:
-            if otp is None:
-                try:
-                    return mgmt.read_device_info()  # Rejected while reclaim
-                except NotSupportedError:
-                    otp = YubiOtpSession(conn)
-            serial = otp.get_serial()  # Rejected if reclaim (or not API_SERIAL_VISIBLE)
-            break
-        except CommandRejectedError:
-            if otp and interfaces == USB_INTERFACE.OTP:
-                break  # Can't be reclaim with only one interface
-            logger.debug("Potential reclaim, sleep...", exc_info=True)
-            sleep(0.5)  # Potential reclaim
-    else:
-        otp = YubiOtpSession(conn)
-
-    # Synthesize info
-    logger.debug("Unable to get info via Management application, use fallback")
-
-    version = otp.version
-    if key_type == YUBIKEY.NEO:
-        usb_supported = BASE_NEO_APPS
-        if USB_INTERFACE.FIDO in interfaces or version >= (3, 3, 0):
-            usb_supported |= CAPABILITY.U2F
-        capabilities = {
-            TRANSPORT.USB: usb_supported,
-            TRANSPORT.NFC: usb_supported,
-        }
-    elif key_type == YUBIKEY.YKP:
-        capabilities = {
-            TRANSPORT.USB: CAPABILITY.OTP | CAPABILITY.U2F,
-        }
-    else:
-        capabilities = {
-            TRANSPORT.USB: CAPABILITY.OTP,
-        }
-
-    return DeviceInfo(
-        config=DeviceConfig(
-            enabled_capabilities={},  # Populated later
-            auto_eject_timeout=0,
-            challenge_response_timeout=0,
-            device_flags=DEVICE_FLAG(0),
-        ),
-        serial=serial,
-        version=version,
-        form_factor=FORM_FACTOR.UNKNOWN,
-        supported_capabilities=capabilities.copy(),
-        is_locked=False,
-    )
-
-
-def _read_info_ctap(conn, key_type, interfaces):
-    try:
-        mgmt = ManagementSession(conn)
-        return mgmt.read_device_info()
-    except Exception:  # SKY 1, NEO, or YKP
-        logger.debug("Unable to get info via Management application, use fallback")
-
-        # Best guess version
-        if key_type == YUBIKEY.YKP:
-            version = Version(4, 0, 0)
-        else:
-            version = Version(3, 0, 0)
-
-        supported_apps = {TRANSPORT.USB: CAPABILITY.U2F}
-        if key_type == YUBIKEY.NEO:
-            supported_apps[TRANSPORT.USB] |= BASE_NEO_APPS
-            supported_apps[TRANSPORT.NFC] = supported_apps[TRANSPORT.USB]
-
-        return DeviceInfo(
-            config=DeviceConfig(
-                enabled_capabilities={},  # Populated later
-                auto_eject_timeout=0,
-                challenge_response_timeout=0,
-                device_flags=DEVICE_FLAG(0),
-            ),
-            serial=None,
-            version=version,
-            form_factor=FORM_FACTOR.USB_A_KEYCHAIN,
-            supported_capabilities=supported_apps,
-            is_locked=False,
-        )
-
-
-def read_info(pid: Optional[PID], conn: Connection) -> DeviceInfo:
-    """Read out a DeviceInfo object from a YubiKey, or attempt to synthesize one."""
-
-    logger.debug(f"Attempting to read device info, using {type(conn).__name__}")
-    if pid:
-        key_type: Optional[YUBIKEY] = pid.get_type()
-        interfaces = pid.get_interfaces()
-    else:  # No PID for NFC connections
-        key_type = None
-        interfaces = USB_INTERFACE(0)
-
-    if isinstance(conn, SmartCardConnection):
-        info = _read_info_ccid(conn, key_type, interfaces)
-    elif isinstance(conn, OtpConnection):
-        info = _read_info_otp(conn, key_type, interfaces)
-    elif isinstance(conn, FidoConnection):
-        info = _read_info_ctap(conn, key_type, interfaces)
-    else:
-        raise TypeError("Invalid connection type")
-
-    logger.debug("Read info: %s", info)
-
-    # Set usb_enabled if missing (pre YubiKey 5)
-    if (
-        info.has_transport(TRANSPORT.USB)
-        and TRANSPORT.USB not in info.config.enabled_capabilities
-    ):
-        usb_enabled = info.supported_capabilities[TRANSPORT.USB]
-        if usb_enabled == (CAPABILITY.OTP | CAPABILITY.U2F | USB_INTERFACE.CCID):
-            # YubiKey Edge, hide unusable CCID interface from supported
-            # usb_enabled = CAPABILITY.OTP | CAPABILITY.U2F
-            info.supported_capabilities = {
-                TRANSPORT.USB: CAPABILITY.OTP | CAPABILITY.U2F
-            }
-
-        if USB_INTERFACE.OTP not in interfaces:
-            usb_enabled &= ~CAPABILITY.OTP
-        if USB_INTERFACE.FIDO not in interfaces:
-            usb_enabled &= ~(CAPABILITY.U2F | CAPABILITY.FIDO2)
-        if USB_INTERFACE.CCID not in interfaces:
-            usb_enabled &= ~(
-                USB_INTERFACE.CCID
-                | CAPABILITY.OATH
-                | CAPABILITY.OPENPGP
-                | CAPABILITY.PIV
-            )
-
-        info.config.enabled_capabilities[TRANSPORT.USB] = usb_enabled
-
-    # YK4-based FIPS version
-    if is_fips_version(info.version):
-        info.is_fips = True
-
-    # Set nfc_enabled if missing (pre YubiKey 5)
-    if (
-        info.has_transport(TRANSPORT.NFC)
-        and TRANSPORT.NFC not in info.config.enabled_capabilities
-    ):
-        info.config.enabled_capabilities[TRANSPORT.NFC] = info.supported_capabilities[
-            TRANSPORT.NFC
-        ]
-
-    # Workaround for invalid configurations.
-    if info.version >= (4, 0, 0):
-        if info.form_factor in (
-            FORM_FACTOR.USB_A_NANO,
-            FORM_FACTOR.USB_C_NANO,
-            FORM_FACTOR.USB_C_LIGHTNING,
-        ) or (
-            info.form_factor is FORM_FACTOR.USB_C_KEYCHAIN and info.version < (5, 2, 4)
-        ):
-            # Known not to have NFC
-            info.supported_capabilities.pop(TRANSPORT.NFC, None)
-            info.config.enabled_capabilities.pop(TRANSPORT.NFC, None)
-
-    logger.debug("Device info, after tweaks: %s", info)
-    return info
-
-
-def _fido_only(capabilities):
-    return capabilities & ~(CAPABILITY.U2F | CAPABILITY.FIDO2) == 0
-
-
-def _is_preview(version):
-    _PREVIEW_RANGES = (
-        ((5, 0, 0), (5, 1, 0)),
-        ((5, 2, 0), (5, 2, 3)),
-        ((5, 5, 0), (5, 5, 2)),
-    )
-    for start, end in _PREVIEW_RANGES:
-        if start <= version < end:
-            return True
-    return False
-
-
-def get_name(info: DeviceInfo, key_type: Optional[YUBIKEY]) -> str:
-    """Determine the product name of a YubiKey"""
-    usb_supported = info.supported_capabilities[TRANSPORT.USB]
-    if not key_type:
-        if info.serial is None and _fido_only(usb_supported):
-            key_type = YUBIKEY.SKY
-        elif info.version[0] == 3:
-            key_type = YUBIKEY.NEO
-        else:
-            key_type = YUBIKEY.YK4
-
-    device_name = key_type.value
-
-    if key_type == YUBIKEY.SKY:
-        if CAPABILITY.FIDO2 not in usb_supported:
-            device_name = "FIDO U2F Security Key"  # SKY 1
-        if info.has_transport(TRANSPORT.NFC):
-            device_name = "Security Key NFC"
-    elif key_type == YUBIKEY.YK4:
-        major_version = info.version[0]
-        if major_version < 4:
-            if info.version[0] == 0:
-                return f"YubiKey ({info.version})"
-            else:
-                return "YubiKey"
-        elif major_version == 4:
-            if is_fips_version(info.version):  # YK4 FIPS
-                device_name = "YubiKey FIPS"
-            elif usb_supported == CAPABILITY.OTP | CAPABILITY.U2F:
-                device_name = "YubiKey Edge"
-            else:
-                device_name = "YubiKey 4"
-
-        if _is_preview(info.version):
-            device_name = "YubiKey Preview"
-        elif info.version >= (5, 1, 0):
-            is_nano = info.form_factor in (
-                FORM_FACTOR.USB_A_NANO,
-                FORM_FACTOR.USB_C_NANO,
-            )
-            is_bio = info.form_factor in (FORM_FACTOR.USB_A_BIO, FORM_FACTOR.USB_C_BIO)
-            is_c = info.form_factor in (  # Does NOT include Ci
-                FORM_FACTOR.USB_C_KEYCHAIN,
-                FORM_FACTOR.USB_C_NANO,
-                FORM_FACTOR.USB_C_BIO,
-            )
-
-            if info.is_sky:
-                name_parts = ["Security Key"]
-            else:
-                name_parts = ["YubiKey"]
-                if not is_bio:
-                    name_parts.append("5")
-            if is_c:
-                name_parts.append("C")
-            elif info.form_factor == FORM_FACTOR.USB_C_LIGHTNING:
-                name_parts.append("Ci")
-            if is_nano:
-                name_parts.append("Nano")
-            if info.has_transport(TRANSPORT.NFC):
-                name_parts.append("NFC")
-            elif info.form_factor == FORM_FACTOR.USB_A_KEYCHAIN:
-                name_parts.append("A")  # Only for non-NFC A Keychain.
-            if is_bio:
-                name_parts.append("Bio")
-                if _fido_only(usb_supported):
-                    name_parts.append("- FIDO Edition")
-            if info.is_fips:
-                name_parts.append("FIPS")
-            device_name = " ".join(name_parts).replace("5 C", "5C").replace("5 A", "5A")
-
-    return device_name

--- a/ykman/diagnostics.py
+++ b/ykman/diagnostics.py
@@ -2,7 +2,6 @@ from . import __version__ as ykman_version
 from .util import get_windows_version
 from .pcsc import list_readers, list_devices as list_ccid_devices
 from .hid import list_otp_devices, list_ctap_devices
-from .device import read_info, get_name
 from .piv import get_piv_info
 from .openpgp import OpenPgpController, get_openpgp_info
 
@@ -13,6 +12,7 @@ from yubikit.management import ManagementSession
 from yubikit.yubiotp import YubiOtpSession
 from yubikit.piv import PivSession
 from yubikit.oath import OathSession
+from yubikit.support import read_info, get_name
 from fido2.ctap import CtapError
 from fido2.ctap2 import Ctap2, ClientPin
 
@@ -61,7 +61,7 @@ def mgmt_info(pid, conn):
         data.append(
             {
                 "DeviceInfo": asdict(info),
-                "Name": get_name(info, pid.get_type()),
+                "Name": get_name(info, pid.yubikey_type),
             }
         )
     except Exception as e:

--- a/ykman/diagnostics.py
+++ b/ykman/diagnostics.py
@@ -57,7 +57,7 @@ def mgmt_info(pid, conn):
         data.append(f"Failed to read device info via Management: {e!r}")
 
     try:
-        info = read_info(pid, conn)
+        info = read_info(conn, pid)
         data.append(
             {
                 "DeviceInfo": asdict(info),

--- a/ykman/hid/base.py
+++ b/ykman/hid/base.py
@@ -25,8 +25,8 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from ..base import YkmanDevice, PID
-from yubikit.core import TRANSPORT
+from yubikit.core import TRANSPORT, PID
+from ..base import YkmanDevice
 
 YUBICO_VID = 0x1050
 

--- a/ykman/openpgp.py
+++ b/ykman/openpgp.py
@@ -26,14 +26,19 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from yubikit.core import (
-    AID,
     Tlv,
     NotSupportedError,
     require_version,
     int2bytes,
     bytes2int,
 )
-from yubikit.core.smartcard import SmartCardConnection, SmartCardProtocol, ApduError, SW
+from yubikit.core.smartcard import (
+    SmartCardConnection,
+    SmartCardProtocol,
+    ApduError,
+    AID,
+    SW,
+)
 
 from cryptography import x509
 from cryptography.hazmat.backends import default_backend

--- a/ykman/pcsc/__init__.py
+++ b/ykman/pcsc/__init__.py
@@ -25,11 +25,11 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from yubikit.core import TRANSPORT
+from ..base import YkmanDevice
+from yubikit.core import TRANSPORT, YUBIKEY, PID
 from yubikit.core.smartcard import SmartCardConnection
 from yubikit.management import USB_INTERFACE
 from yubikit.logging import LOG_LEVEL
-from ..base import YUBIKEY, YkmanDevice
 
 from smartcard import System
 from smartcard.Exceptions import CardConnectionException
@@ -61,7 +61,7 @@ def _pid_from_name(name):
         interfaces |= USB_INTERFACE.FIDO
 
     key_type = YUBIKEY.NEO if "NEO" in name else YUBIKEY.YK4
-    return key_type.get_pid(interfaces)
+    return PID.of(key_type, interfaces)
 
 
 class ScardYubiKeyDevice(YkmanDevice):

--- a/ykman/scripting.py
+++ b/ykman/scripting.py
@@ -27,7 +27,7 @@
 
 
 from .base import YkmanDevice
-from .device import list_all_devices, scan_devices, get_name, read_info
+from .device import list_all_devices, scan_devices
 from .pcsc import list_devices as list_ccid
 
 from yubikit.core import TRANSPORT
@@ -35,6 +35,7 @@ from yubikit.core.otp import OtpConnection
 from yubikit.core.smartcard import SmartCardConnection
 from yubikit.core.fido import FidoConnection
 from yubikit.management import DeviceInfo
+from yubikit.support import get_name, read_info
 from smartcard.Exceptions import NoCardException, CardConnectionException
 
 from time import sleep
@@ -76,7 +77,7 @@ class ScriptingDevice:
         return getattr(self._wrapped, attr)
 
     def __str__(self):
-        name = get_name(self._info, self.pid.get_type() if self.pid else None)
+        name = get_name(self._info, self.pid.yubikey_type if self.pid else None)
         serial = self._info.serial
         return f"{name} ({serial})" if serial else name
 

--- a/ykman/scripting.py
+++ b/ykman/scripting.py
@@ -162,7 +162,7 @@ def single_nfc(reader="", *, prompt=True) -> ScriptingDevice:
     while True:
         try:
             with device.open_connection(SmartCardConnection) as connection:
-                info = read_info(None, connection)
+                info = read_info(connection)
             return ScriptingDevice(device, info)
         except NoCardException:
             if prompt:
@@ -192,7 +192,7 @@ def multi_nfc(
     while True:  # Run this until we stop the script with Ctrl+C
         try:
             with device.open_connection(SmartCardConnection) as connection:
-                info = read_info(None, connection)
+                info = read_info(connection)
             if info.serial in handled_serials or current == info.serial:
                 if prompt and not prompted:
                     print("Remove YubiKey from NFC reader.")

--- a/ykman/util.py
+++ b/ykman/util.py
@@ -51,7 +51,9 @@ def _parse_pkcs12(data, password):
         key, cert, cas = pkcs12.load_key_and_certificates(
             data, password, default_backend()
         )
-        return key, [cert] + cas
+        if cert:
+            cas.insert(0, cert)
+        return key, cas
     except ValueError as e:  # cryptography raises ValueError on wrong password
         raise InvalidPasswordError(e)
 

--- a/yubikit/core/fido.py
+++ b/yubikit/core/fido.py
@@ -25,10 +25,11 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from . import Connection
+from . import Connection, USB_INTERFACE
 from fido2.ctap import CtapDevice
 
 
 # Make CtapDevice a Connection
 FidoConnection = CtapDevice
+FidoConnection.usb_interface = USB_INTERFACE.FIDO
 Connection.register(FidoConnection)

--- a/yubikit/core/otp.py
+++ b/yubikit/core/otp.py
@@ -25,7 +25,7 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from . import Connection, CommandError, TimeoutError, Version
+from . import Connection, CommandError, TimeoutError, Version, USB_INTERFACE
 from yubikit.logging import LOG_LEVEL
 
 from time import sleep
@@ -46,6 +46,8 @@ class CommandRejectedError(CommandError):
 
 
 class OtpConnection(Connection, metaclass=abc.ABCMeta):
+    _usb_interface = USB_INTERFACE.OTP
+
     @abc.abstractmethod
     def receive(self) -> bytes:
         """Reads an 8 byte feature report"""

--- a/yubikit/core/otp.py
+++ b/yubikit/core/otp.py
@@ -46,7 +46,7 @@ class CommandRejectedError(CommandError):
 
 
 class OtpConnection(Connection, metaclass=abc.ABCMeta):
-    _usb_interface = USB_INTERFACE.OTP
+    usb_interface = USB_INTERFACE.OTP
 
     @abc.abstractmethod
     def receive(self) -> bytes:

--- a/yubikit/core/smartcard.py
+++ b/yubikit/core/smartcard.py
@@ -25,7 +25,14 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from . import Version, TRANSPORT, Connection, CommandError, ApplicationNotAvailableError
+from . import (
+    Version,
+    TRANSPORT,
+    USB_INTERFACE,
+    Connection,
+    CommandError,
+    ApplicationNotAvailableError,
+)
 from time import time
 from enum import Enum, IntEnum, unique
 from typing import Tuple
@@ -34,17 +41,6 @@ import struct
 import logging
 
 logger = logging.getLogger(__name__)
-
-
-class SmartCardConnection(Connection, metaclass=abc.ABCMeta):
-    @property
-    @abc.abstractmethod
-    def transport(self) -> TRANSPORT:
-        """Get the transport type of the connection (USB or NFC)"""
-
-    @abc.abstractmethod
-    def send_and_receive(self, apdu: bytes) -> Tuple[bytes, int]:
-        """Sends a command APDU and returns the response"""
 
 
 class ApduError(CommandError):
@@ -67,6 +63,19 @@ class ApduFormat(str, Enum):
 
 
 @unique
+class AID(bytes, Enum):
+    """YubiKey Application smart card AID values."""
+
+    OTP = bytes.fromhex("a0000005272001")
+    MANAGEMENT = bytes.fromhex("a000000527471117")
+    OPENPGP = bytes.fromhex("d27600012401")
+    OATH = bytes.fromhex("a0000005272101")
+    PIV = bytes.fromhex("a000000308")
+    FIDO = bytes.fromhex("a0000006472f0001")
+    HSMAUTH = bytes.fromhex("a000000527210701")
+
+
+@unique
 class SW(IntEnum):
     NO_INPUT_DATA = 0x6285
     VERIFY_FAIL_NO_RETRY = 0x63C0
@@ -85,6 +94,19 @@ class SW(IntEnum):
     INVALID_INSTRUCTION = 0x6D00
     COMMAND_ABORTED = 0x6F00
     OK = 0x9000
+
+
+class SmartCardConnection(Connection, metaclass=abc.ABCMeta):
+    _usb_interface = USB_INTERFACE.CCID
+
+    @property
+    @abc.abstractmethod
+    def transport(self) -> TRANSPORT:
+        """Get the transport type of the connection (USB or NFC)"""
+
+    @abc.abstractmethod
+    def send_and_receive(self, apdu: bytes) -> Tuple[bytes, int]:
+        """Sends a command APDU and returns the response"""
 
 
 INS_SELECT = 0xA4

--- a/yubikit/core/smartcard.py
+++ b/yubikit/core/smartcard.py
@@ -97,7 +97,7 @@ class SW(IntEnum):
 
 
 class SmartCardConnection(Connection, metaclass=abc.ABCMeta):
-    _usb_interface = USB_INTERFACE.CCID
+    usb_interface = USB_INTERFACE.CCID
 
     @property
     @abc.abstractmethod

--- a/yubikit/oath.py
+++ b/yubikit/oath.py
@@ -4,10 +4,9 @@ from .core import (
     require_version,
     Version,
     Tlv,
-    AID,
     BadResponseError,
 )
-from .core.smartcard import SmartCardConnection, SmartCardProtocol
+from .core.smartcard import AID, SmartCardConnection, SmartCardProtocol
 
 from urllib.parse import unquote, urlparse, parse_qs
 from functools import total_ordering

--- a/yubikit/piv.py
+++ b/yubikit/piv.py
@@ -31,17 +31,17 @@ from .core import (
     bytes2int,
     Version,
     Tlv,
-    AID,
     CommandError,
     NotSupportedError,
     BadResponseError,
 )
 from .core.smartcard import (
+    SW,
+    AID,
+    ApduError,
+    ApduFormat,
     SmartCardConnection,
     SmartCardProtocol,
-    ApduError,
-    SW,
-    ApduFormat,
 )
 
 from cryptography import x509

--- a/yubikit/support.py
+++ b/yubikit/support.py
@@ -59,7 +59,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def is_fips_version(version: Version) -> bool:
+def is_yk4_fips_version(version: Version) -> bool:
     """True if a given firmware version indicates a YubiKey (4) FIPS"""
     return (4, 4, 0) <= version < (4, 5, 0)
 
@@ -304,7 +304,7 @@ def read_info(pid: Optional[PID], conn: Connection) -> DeviceInfo:
         info.config.enabled_capabilities[TRANSPORT.USB] = usb_enabled
 
     # YK4-based FIPS version
-    if is_fips_version(info.version):
+    if is_yk4_fips_version(info.version):
         info.is_fips = True
 
     # Set nfc_enabled if missing (pre YubiKey 5)
@@ -375,7 +375,7 @@ def get_name(info: DeviceInfo, key_type: Optional[YUBIKEY]) -> str:
             else:
                 return "YubiKey"
         elif major_version == 4:
-            if is_fips_version(info.version):  # YK4 FIPS
+            if is_yk4_fips_version(info.version):  # YK4 FIPS
                 device_name = "YubiKey FIPS"
             elif usb_supported == CAPABILITY.OTP | CAPABILITY.U2F:
                 device_name = "YubiKey Edge"

--- a/yubikit/support.py
+++ b/yubikit/support.py
@@ -1,0 +1,423 @@
+# Copyright (c) 2015-2022 Yubico AB
+# All rights reserved.
+#
+#   Redistribution and use in source and binary forms, with or
+#   without modification, are permitted provided that the following
+#   conditions are met:
+#
+#    1. Redistributions of source code must retain the above copyright
+#       notice, this list of conditions and the following disclaimer.
+#    2. Redistributions in binary form must reproduce the above
+#       copyright notice, this list of conditions and the following
+#       disclaimer in the documentation and/or other materials provided
+#       with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+from .core import (
+    TRANSPORT,
+    YUBIKEY,
+    PID,
+    Version,
+    Connection,
+    NotSupportedError,
+    ApplicationNotAvailableError,
+)
+from .core.otp import OtpConnection, CommandRejectedError
+from .core.fido import FidoConnection
+from .core.smartcard import (
+    AID,
+    SmartCardConnection,
+    SmartCardProtocol,
+)
+from .management import (
+    ManagementSession,
+    DeviceInfo,
+    DeviceConfig,
+    USB_INTERFACE,
+    CAPABILITY,
+    FORM_FACTOR,
+    DEVICE_FLAG,
+)
+from .yubiotp import YubiOtpSession
+
+from time import sleep
+from typing import Optional, Tuple
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def is_fips_version(version: Version) -> bool:
+    """True if a given firmware version indicates a YubiKey (4) FIPS"""
+    return (4, 4, 0) <= version < (4, 5, 0)
+
+
+def _otp_read_data(conn) -> Tuple[Version, Optional[int]]:
+    otp = YubiOtpSession(conn)
+    version = otp.version
+    serial: Optional[int] = None
+    try:
+        serial = otp.get_serial()
+    except Exception:
+        logger.debug("Unable to read serial over OTP, no serial", exc_info=True)
+    return version, serial
+
+
+AID_U2F_YUBICO = b"\xa0\x00\x00\x05\x27\x10\x02"  # Old U2F AID
+
+SCAN_APPLETS = {
+    # AID.OTP: CAPABILITY.OTP,  # NB: OTP will be checked elsewhere
+    AID.FIDO: CAPABILITY.U2F,
+    AID_U2F_YUBICO: CAPABILITY.U2F,
+    AID.PIV: CAPABILITY.PIV,
+    AID.OPENPGP: CAPABILITY.OPENPGP,
+    AID.OATH: CAPABILITY.OATH,
+}
+
+BASE_NEO_APPS = CAPABILITY.OTP | CAPABILITY.OATH | CAPABILITY.PIV | CAPABILITY.OPENPGP
+
+
+def _read_info_ccid(conn, key_type, interfaces):
+    version: Optional[Version] = None
+    try:
+        mgmt = ManagementSession(conn)
+        version = mgmt.version
+        try:
+            return mgmt.read_device_info()
+        except NotSupportedError:
+            # Workaround to "de-select" the Management Applet needed for NEO
+            conn.send_and_receive(b"\xa4\x04\x00\x08")
+    except ApplicationNotAvailableError:
+        logger.debug("Couldn't select Management application, use fallback")
+
+    # Synthesize data
+    capabilities = CAPABILITY(0)
+
+    # Try to read serial (and version if needed) from OTP application
+    try:
+        otp_version, serial = _otp_read_data(conn)
+        capabilities |= CAPABILITY.OTP
+        if version is None:
+            version = otp_version
+    except ApplicationNotAvailableError:
+        logger.debug("Couldn't select OTP application, serial unknown")
+        serial = None
+
+    if version is None:
+        logger.debug("Firmware version unknown, using 3.0.0 as a baseline")
+        version = Version(3, 0, 0)  # Guess, no way to know
+
+    # Scan for remaining capabilities
+    logger.debug("Scan for available applications...")
+    protocol = SmartCardProtocol(conn)
+    for aid, code in SCAN_APPLETS.items():
+        try:
+            protocol.select(aid)
+            capabilities |= code
+            logger.debug("Found applet: aid: %s, capability: %s", aid, code)
+        except ApplicationNotAvailableError:
+            logger.debug("Missing applet: aid: %s, capability: %s", aid, code)
+        except Exception:
+            logger.exception(
+                "Error selecting aid: %s, capability: %s",
+                aid,
+                code,
+            )
+
+    # Assume U2F on devices >= 3.3.0
+    if USB_INTERFACE.FIDO in interfaces or version >= (3, 3, 0):
+        capabilities |= CAPABILITY.U2F
+
+    return DeviceInfo(
+        config=DeviceConfig(
+            enabled_capabilities={},  # Populated later
+            auto_eject_timeout=0,
+            challenge_response_timeout=0,
+            device_flags=DEVICE_FLAG(0),
+        ),
+        serial=serial,
+        version=version,
+        form_factor=FORM_FACTOR.UNKNOWN,
+        supported_capabilities={
+            TRANSPORT.USB: capabilities,
+            TRANSPORT.NFC: capabilities,
+        },
+        is_locked=False,
+    )
+
+
+def _read_info_otp(conn, key_type, interfaces):
+    otp = None
+    serial = None
+
+    try:
+        mgmt = ManagementSession(conn)
+    except ApplicationNotAvailableError:
+        otp = YubiOtpSession(conn)
+
+    # Retry during potential reclaim timeout period (~3s).
+    for _ in range(8):
+        try:
+            if otp is None:
+                try:
+                    return mgmt.read_device_info()  # Rejected while reclaim
+                except NotSupportedError:
+                    otp = YubiOtpSession(conn)
+            serial = otp.get_serial()  # Rejected if reclaim (or not API_SERIAL_VISIBLE)
+            break
+        except CommandRejectedError:
+            if otp and interfaces == USB_INTERFACE.OTP:
+                break  # Can't be reclaim with only one interface
+            logger.debug("Potential reclaim, sleep...", exc_info=True)
+            sleep(0.5)  # Potential reclaim
+    else:
+        otp = YubiOtpSession(conn)
+
+    # Synthesize info
+    logger.debug("Unable to get info via Management application, use fallback")
+
+    version = otp.version
+    if key_type == YUBIKEY.NEO:
+        usb_supported = BASE_NEO_APPS
+        if USB_INTERFACE.FIDO in interfaces or version >= (3, 3, 0):
+            usb_supported |= CAPABILITY.U2F
+        capabilities = {
+            TRANSPORT.USB: usb_supported,
+            TRANSPORT.NFC: usb_supported,
+        }
+    elif key_type == YUBIKEY.YKP:
+        capabilities = {
+            TRANSPORT.USB: CAPABILITY.OTP | CAPABILITY.U2F,
+        }
+    else:
+        capabilities = {
+            TRANSPORT.USB: CAPABILITY.OTP,
+        }
+
+    return DeviceInfo(
+        config=DeviceConfig(
+            enabled_capabilities={},  # Populated later
+            auto_eject_timeout=0,
+            challenge_response_timeout=0,
+            device_flags=DEVICE_FLAG(0),
+        ),
+        serial=serial,
+        version=version,
+        form_factor=FORM_FACTOR.UNKNOWN,
+        supported_capabilities=capabilities.copy(),
+        is_locked=False,
+    )
+
+
+def _read_info_ctap(conn, key_type, interfaces):
+    try:
+        mgmt = ManagementSession(conn)
+        return mgmt.read_device_info()
+    except Exception:  # SKY 1, NEO, or YKP
+        logger.debug("Unable to get info via Management application, use fallback")
+
+        # Best guess version
+        if key_type == YUBIKEY.YKP:
+            version = Version(4, 0, 0)
+        else:
+            version = Version(3, 0, 0)
+
+        supported_apps = {TRANSPORT.USB: CAPABILITY.U2F}
+        if key_type == YUBIKEY.NEO:
+            supported_apps[TRANSPORT.USB] |= BASE_NEO_APPS
+            supported_apps[TRANSPORT.NFC] = supported_apps[TRANSPORT.USB]
+
+        return DeviceInfo(
+            config=DeviceConfig(
+                enabled_capabilities={},  # Populated later
+                auto_eject_timeout=0,
+                challenge_response_timeout=0,
+                device_flags=DEVICE_FLAG(0),
+            ),
+            serial=None,
+            version=version,
+            form_factor=FORM_FACTOR.USB_A_KEYCHAIN,
+            supported_capabilities=supported_apps,
+            is_locked=False,
+        )
+
+
+def read_info(pid: Optional[PID], conn: Connection) -> DeviceInfo:
+    """Read out a DeviceInfo object from a YubiKey, or attempt to synthesize one."""
+
+    logger.debug(f"Attempting to read device info, using {type(conn).__name__}")
+    if pid:
+        key_type: Optional[YUBIKEY] = pid.yubikey_type
+        interfaces = pid.usb_interfaces
+    else:  # No PID for NFC connections
+        key_type = None
+        interfaces = USB_INTERFACE(0)
+
+    if isinstance(conn, SmartCardConnection):
+        info = _read_info_ccid(conn, key_type, interfaces)
+    elif isinstance(conn, OtpConnection):
+        info = _read_info_otp(conn, key_type, interfaces)
+    elif isinstance(conn, FidoConnection):
+        info = _read_info_ctap(conn, key_type, interfaces)
+    else:
+        raise TypeError("Invalid connection type")
+
+    logger.debug("Read info: %s", info)
+
+    # Set usb_enabled if missing (pre YubiKey 5)
+    if (
+        info.has_transport(TRANSPORT.USB)
+        and TRANSPORT.USB not in info.config.enabled_capabilities
+    ):
+        usb_enabled = info.supported_capabilities[TRANSPORT.USB]
+        if usb_enabled == (CAPABILITY.OTP | CAPABILITY.U2F | USB_INTERFACE.CCID):
+            # YubiKey Edge, hide unusable CCID interface from supported
+            # usb_enabled = CAPABILITY.OTP | CAPABILITY.U2F
+            info.supported_capabilities = {
+                TRANSPORT.USB: CAPABILITY.OTP | CAPABILITY.U2F
+            }
+
+        if USB_INTERFACE.OTP not in interfaces:
+            usb_enabled &= ~CAPABILITY.OTP
+        if USB_INTERFACE.FIDO not in interfaces:
+            usb_enabled &= ~(CAPABILITY.U2F | CAPABILITY.FIDO2)
+        if USB_INTERFACE.CCID not in interfaces:
+            usb_enabled &= ~(
+                USB_INTERFACE.CCID
+                | CAPABILITY.OATH
+                | CAPABILITY.OPENPGP
+                | CAPABILITY.PIV
+            )
+
+        info.config.enabled_capabilities[TRANSPORT.USB] = usb_enabled
+
+    # YK4-based FIPS version
+    if is_fips_version(info.version):
+        info.is_fips = True
+
+    # Set nfc_enabled if missing (pre YubiKey 5)
+    if (
+        info.has_transport(TRANSPORT.NFC)
+        and TRANSPORT.NFC not in info.config.enabled_capabilities
+    ):
+        info.config.enabled_capabilities[TRANSPORT.NFC] = info.supported_capabilities[
+            TRANSPORT.NFC
+        ]
+
+    # Workaround for invalid configurations.
+    if info.version >= (4, 0, 0):
+        if info.form_factor in (
+            FORM_FACTOR.USB_A_NANO,
+            FORM_FACTOR.USB_C_NANO,
+            FORM_FACTOR.USB_C_LIGHTNING,
+        ) or (
+            info.form_factor is FORM_FACTOR.USB_C_KEYCHAIN and info.version < (5, 2, 4)
+        ):
+            # Known not to have NFC
+            info.supported_capabilities.pop(TRANSPORT.NFC, None)
+            info.config.enabled_capabilities.pop(TRANSPORT.NFC, None)
+
+    logger.debug("Device info, after tweaks: %s", info)
+    return info
+
+
+def _fido_only(capabilities):
+    return capabilities & ~(CAPABILITY.U2F | CAPABILITY.FIDO2) == 0
+
+
+def _is_preview(version):
+    _PREVIEW_RANGES = (
+        ((5, 0, 0), (5, 1, 0)),
+        ((5, 2, 0), (5, 2, 3)),
+        ((5, 5, 0), (5, 5, 2)),
+    )
+    for start, end in _PREVIEW_RANGES:
+        if start <= version < end:
+            return True
+    return False
+
+
+def get_name(info: DeviceInfo, key_type: Optional[YUBIKEY]) -> str:
+    """Determine the product name of a YubiKey"""
+    usb_supported = info.supported_capabilities[TRANSPORT.USB]
+    if not key_type:
+        if info.serial is None and _fido_only(usb_supported):
+            key_type = YUBIKEY.SKY
+        elif info.version[0] == 3:
+            key_type = YUBIKEY.NEO
+        else:
+            key_type = YUBIKEY.YK4
+
+    device_name = key_type.value
+
+    if key_type == YUBIKEY.SKY:
+        if CAPABILITY.FIDO2 not in usb_supported:
+            device_name = "FIDO U2F Security Key"  # SKY 1
+        if info.has_transport(TRANSPORT.NFC):
+            device_name = "Security Key NFC"
+    elif key_type == YUBIKEY.YK4:
+        major_version = info.version[0]
+        if major_version < 4:
+            if info.version[0] == 0:
+                return f"YubiKey ({info.version})"
+            else:
+                return "YubiKey"
+        elif major_version == 4:
+            if is_fips_version(info.version):  # YK4 FIPS
+                device_name = "YubiKey FIPS"
+            elif usb_supported == CAPABILITY.OTP | CAPABILITY.U2F:
+                device_name = "YubiKey Edge"
+            else:
+                device_name = "YubiKey 4"
+
+        if _is_preview(info.version):
+            device_name = "YubiKey Preview"
+        elif info.version >= (5, 1, 0):
+            is_nano = info.form_factor in (
+                FORM_FACTOR.USB_A_NANO,
+                FORM_FACTOR.USB_C_NANO,
+            )
+            is_bio = info.form_factor in (FORM_FACTOR.USB_A_BIO, FORM_FACTOR.USB_C_BIO)
+            is_c = info.form_factor in (  # Does NOT include Ci
+                FORM_FACTOR.USB_C_KEYCHAIN,
+                FORM_FACTOR.USB_C_NANO,
+                FORM_FACTOR.USB_C_BIO,
+            )
+
+            if info.is_sky:
+                name_parts = ["Security Key"]
+            else:
+                name_parts = ["YubiKey"]
+                if not is_bio:
+                    name_parts.append("5")
+            if is_c:
+                name_parts.append("C")
+            elif info.form_factor == FORM_FACTOR.USB_C_LIGHTNING:
+                name_parts.append("Ci")
+            if is_nano:
+                name_parts.append("Nano")
+            if info.has_transport(TRANSPORT.NFC):
+                name_parts.append("NFC")
+            elif info.form_factor == FORM_FACTOR.USB_A_KEYCHAIN:
+                name_parts.append("A")  # Only for non-NFC A Keychain.
+            if is_bio:
+                name_parts.append("Bio")
+                if _fido_only(usb_supported):
+                    name_parts.append("- FIDO Edition")
+            if info.is_fips:
+                name_parts.append("FIPS")
+            device_name = " ".join(name_parts).replace("5 C", "5C").replace("5 A", "5A")
+
+    return device_name

--- a/yubikit/support.py
+++ b/yubikit/support.py
@@ -59,11 +59,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-def is_yk4_fips_version(version: Version) -> bool:
-    """True if a given firmware version indicates a YubiKey (4) FIPS"""
-    return (4, 4, 0) <= version < (4, 5, 0)
-
-
 def _otp_read_data(conn) -> Tuple[Version, Optional[int]]:
     otp = YubiOtpSession(conn)
     version = otp.version
@@ -316,7 +311,7 @@ def read_info(conn: Connection, pid: Optional[PID] = None) -> DeviceInfo:
         info.config.enabled_capabilities[TRANSPORT.USB] = usb_enabled
 
     # YK4-based FIPS version
-    if is_yk4_fips_version(info.version):
+    if (4, 4, 0) <= info.version < (4, 5, 0):
         info.is_fips = True
 
     # Set nfc_enabled if missing (pre YubiKey 5)
@@ -387,7 +382,7 @@ def get_name(info: DeviceInfo, key_type: Optional[YUBIKEY]) -> str:
             else:
                 return "YubiKey"
         elif major_version == 4:
-            if is_yk4_fips_version(info.version):  # YK4 FIPS
+            if info.is_fips:
                 device_name = "YubiKey FIPS"
             elif usb_supported == CAPABILITY.OTP | CAPABILITY.U2F:
                 device_name = "YubiKey Edge"

--- a/yubikit/support.py
+++ b/yubikit/support.py
@@ -310,6 +310,10 @@ def read_info(conn: Connection, pid: Optional[PID] = None) -> DeviceInfo:
 
         info.config.enabled_capabilities[TRANSPORT.USB] = usb_enabled
 
+    # SKY identified by PID
+    if key_type == YUBIKEY.SKY:
+        info.is_sky = True
+
     # YK4-based FIPS version
     if (4, 4, 0) <= info.version < (4, 5, 0):
         info.is_fips = True

--- a/yubikit/support.py
+++ b/yubikit/support.py
@@ -258,8 +258,7 @@ def read_info(conn: Connection, pid: Optional[PID] = None) -> DeviceInfo:
     data using other mechanisms if needed. It will also make adjustments to the data if
     required, for example to "fix" known bad values.
 
-    The *pid* parameter must be provided whenever the YubiKey is connected via USB,
-    else the result may be incorrect.
+    The *pid* parameter must be provided whenever the YubiKey is connected via USB.
     """
 
     logger.debug(f"Attempting to read device info, using {type(conn).__name__}")

--- a/yubikit/yubiotp.py
+++ b/yubikit/yubiotp.py
@@ -26,7 +26,6 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from .core import (
-    AID,
     TRANSPORT,
     Version,
     bytes2int,
@@ -42,7 +41,7 @@ from .core.otp import (
     OtpProtocol,
     CommandRejectedError,
 )
-from .core.smartcard import SmartCardConnection, SmartCardProtocol
+from .core.smartcard import AID, SmartCardConnection, SmartCardProtocol
 
 import abc
 import struct


### PR DESCRIPTION
This adds the yubikit.support module and moves the `read_info` and `get_name` functions there from `ykman.device`. The functionality has been updated to better use the new `is_fips` and `is_sky` properties of `DeviceInfo`, and thus the `is_fips_version` function has been removed. The order of the arguments to `read_info` has also been swapped.

The `YUBIKEY`, `PID`, and `USB_INTERFACE` enums have been moved to `yubikit.core` (from `ykman.base` and `yubikit.management`) and their methods and properties have been changes to make them more useful.

Each Connection type now has a `usb_interface` property identifying which USB interface it is used over.