### PR TITLE
Handle APPLET_SELECT_FAILED in smartcard applet select

### DIFF
--- a/yubikit/core/smartcard.py
+++ b/yubikit/core/smartcard.py
@@ -78,6 +78,7 @@ class SW(IntEnum):
     FILE_NOT_FOUND = 0x6A82
     NO_SPACE = 0x6A84
     REFERENCE_DATA_NOT_FOUND = 0x6A88
+    APPLET_SELECT_FAILED = 0x6999
     WRONG_PARAMETERS_P1P2 = 0x6B00
     INVALID_INSTRUCTION = 0x6D00
     COMMAND_ABORTED = 0x6F00
@@ -128,6 +129,7 @@ class SmartCardProtocol:
         except ApduError as e:
             if e.sw in (
                 SW.FILE_NOT_FOUND,
+                SW.APPLET_SELECT_FAILED,
                 SW.INVALID_INSTRUCTION,
                 SW.WRONG_PARAMETERS_P1P2,
             ):


### PR DESCRIPTION
The `APPLET_SELECT_FAILED` ISO7816 APDU error code (https://docs.oracle.com/javacard/3.0.5/api/javacard/framework/ISO7816.html#SW_APPLET_SELECT_FAILED) is returned by some card environments instead of `FILE_NOT_FOUND` . For example, https://github.com/licel/jcardsim (https://jcardsim.org/) behaves this way when an applet fails to load or was not found.

Without this change, ykman is unable to properly enumerate the installed applets in this environment, which leads to an early abort of any command.