### PR TITLE
Fix order of parameters in YubiHSM Auth CMD.

### DIFF
--- a/tests/device/test_hsmauth.py
+++ b/tests/device/test_hsmauth.py
@@ -96,6 +96,25 @@ class TestCredentialManagement:
         assert credential_retrieved.algorithm == credential.algorithm
         assert credential_retrieved.counter == INITIAL_RETRY_COUNTER
 
+    def verify_credential_password(
+        self, session, credential_password: str, credential: Credential
+    ):
+        context = b"g\xfc\xf1\xfe\xb5\xf1\xd8\x83\xedv=\xbfI0\x90\xbb"
+
+        try:
+            # Try to calculate session keys using credential password
+            session.calculate_session_keys(
+                label=credential.label,
+                context=context,
+                credential_password=credential_password,
+            )
+        except Exception as e:
+            # If wrong credential password, should throw InvalidPinError
+            if isinstance(e, InvalidPinError):
+                return False
+
+        return True
+
     def test_import_credential_symmetric_wrong_management_key(self, session):
         with pytest.raises(InvalidPinError):
             import_key_derived(session, NON_DEFAULT_MANAGEMENT_KEY)
@@ -112,8 +131,9 @@ class TestCredentialManagement:
             import_key_derived(session, DEFAULT_MANAGEMENT_KEY)
 
     def test_import_credential_symmetric_works(self, session):
-        credential = import_key_derived(session, DEFAULT_MANAGEMENT_KEY)
+        credential = import_key_derived(session, DEFAULT_MANAGEMENT_KEY, "1234")
 
+        self.verify_credential_password(session, "1234", credential)
         self.check_credential_in_list(session, credential)
 
         session.delete_credential(DEFAULT_MANAGEMENT_KEY, credential.label)

--- a/ykman/_cli/hsmauth.py
+++ b/ykman/_cli/hsmauth.py
@@ -529,7 +529,7 @@ def derive(ctx, label, derivation_password, credential_password, management_key,
 
     try:
         session.put_credential_derived(
-            management_key, label, credential_password, derivation_password, touch
+            management_key, label, derivation_password, credential_password, touch
         )
     except Exception as e:
         handle_credential_error(


### PR DESCRIPTION
This fixes the wrong order of parameters in the `derive` CLI command for YubiHSM Auth.