### PR TITLE
Add a Dependabot config to update GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This PR introduces the following change:

* Add a Dependabot configuration to update GitHub action versions via PRs.

There are several actions that are no longer current (`actions/checkout@v3` is now at v4 for example, and `actions/upload-artifact@v1` is now at v3). Rather than submit a PR to update these just once, the new Dependabot config will make sure they stay up-to-date on a regular basis.