### PR TITLE
PIV: Improve handling of legacy "PUK blocked" flag

### DIFF
--- a/tests/device/cli/piv/test_fips.py
+++ b/tests/device/cli/piv/test_fips.py
@@ -1,22 +1,16 @@
-from yubikit.management import CAPABILITY
 from yubikit.core import NotSupportedError
 from ....util import open_file
 from ... import condition
 import pytest
 
 
-@pytest.fixture(autouse=True)
-@condition.yk4_fips(True)
-@condition.capability(CAPABILITY.PIV)
-def ensure_piv(ykman_cli):
-    ykman_cli("piv", "reset", "-f")
-
-
 class TestFIPS:
+    @condition.yk4_fips(True)
     def test_rsa1024_generate_blocked(self, ykman_cli):
         with pytest.raises(NotSupportedError):
             ykman_cli("piv", "keys", "generate", "9a", "-a", "RSA1024", "-")
 
+    @condition.yk4_fips(True)
     def test_rsa1024_import_blocked(self, ykman_cli):
         with pytest.raises(NotSupportedError):
             with open_file("rsa_1024_key.pem") as f:

--- a/tests/device/cli/piv/test_pin_puk.py
+++ b/tests/device/cli/piv/test_pin_puk.py
@@ -6,7 +6,6 @@ from .util import (
     NON_DEFAULT_PUK,
     DEFAULT_MANAGEMENT_KEY,
 )
-from ... import condition
 from ykman.piv import OBJECT_ID_PIVMAN_DATA, PivmanData
 
 import pytest
@@ -98,7 +97,7 @@ class TestPuk:
 
 
 class TestSetRetries:
-    def test_set_retries(self, ykman_cli):
+    def test_set_retries(self, ykman_cli, version):
         ykman_cli(
             "piv",
             "access",
@@ -110,11 +109,22 @@ class TestSetRetries:
 
         o = ykman_cli("piv", "info").output
         assert re.search(r"PIN tries remaining:\s+5(/5)?", o)
-        if re.search(r"PUK tries remaining", o):
+        if version >= (5, 3):
             assert re.search(r"PUK tries remaining:\s+6/6", o)
 
-    @condition.min_version(5, 3)
     def test_set_retries_clears_puk_blocked(self, ykman_cli):
+        for _ in range(3):
+            with pytest.raises(SystemExit):
+                ykman_cli(
+                    "piv",
+                    "access",
+                    "change-puk",
+                    "-p",
+                    NON_DEFAULT_PUK,
+                    "-n",
+                    DEFAULT_PUK,
+                )
+
         pivman = PivmanData()
         pivman.puk_blocked = True
 

--- a/ykman/_cli/piv.py
+++ b/ykman/_cli/piv.py
@@ -52,6 +52,7 @@ from ..piv import (
     get_pivman_protected_data,
     pivman_set_mgm_key,
     pivman_change_pin,
+    pivman_set_pin_attempts,
     derive_management_key,
     generate_random_management_key,
     generate_chuid,
@@ -266,7 +267,7 @@ def set_pin_retries(ctx, management_key, pin, pin_retries, puk_retries, force):
         err=True,
     )
     try:
-        session.set_pin_attempts(pin_retries, puk_retries)
+        pivman_set_pin_attempts(session, pin_retries, puk_retries)
         click.echo("Default PINs are set:")
         click.echo("\tPIN:\t123456")
         click.echo("\tPUK:\t12345678")

--- a/ykman/piv.py
+++ b/ykman/piv.py
@@ -510,20 +510,20 @@ def get_piv_info(session: PivSession):
         tries = session.get_pin_attempts()
         tries_str = "15 or more" if tries == 15 else str(tries)
     info["PIN tries remaining"] = tries_str
-    if pivman.puk_blocked:
-        lines.append("PUK is blocked")
-    else:
-        try:
-            puk_data = session.get_puk_metadata()
-            if puk_data.default_value:
-                lines.append("WARNING: Using default PUK!")
-            tries_str = "%d/%d" % (
-                puk_data.attempts_remaining,
-                puk_data.total_attempts,
-            )
-            info["PUK tries remaining"] = tries_str
-        except NotSupportedError:
-            pass
+    try:
+        puk_data = session.get_puk_metadata()
+        if puk_data.attempts_remaining == 0:
+            lines.append("PUK is blocked")
+        elif puk_data.default_value:
+            lines.append("WARNING: Using default PUK!")
+        tries_str = "%d/%d" % (
+            puk_data.attempts_remaining,
+            puk_data.total_attempts,
+        )
+        info["PUK tries remaining"] = tries_str
+    except NotSupportedError:
+        if pivman.puk_blocked:
+            lines.append("PUK is blocked")
 
     try:
         metadata = session.get_management_key_metadata()


### PR DESCRIPTION
Ignore it on newer devices with metadata support, and make sure to clear the flag on set-retries.