### PR TITLE
Fix undefined variable

### DIFF
--- a/ykman/hid/linux.py
+++ b/ykman/hid/linux.py
@@ -126,7 +126,7 @@ def list_devices():
                 _failed_cache.add(hidraw)
             continue
 
-    # Remove entries from the cache that were not seen
-    _failed_cache.difference_update(hidraw)
+        # Remove entries from the cache that were not seen
+        _failed_cache.difference_update(hidraw)
 
     return devices


### PR DESCRIPTION
I am using yubikey-manager as a library, and, when calling `list_all_devices()` on a Linux machine, that has no YubiKeys attached, I am getting the following exception:

```
Unable to list devices for connection
Traceback (most recent call last):
  File "/home/ay/projects/personal/yop/.direnv/python-3.12.1/lib/python3.12/site-packages/ykman/device.py", line 291, in list_all_devices
    for dev in _CONNECTION_LIST_MAPPING[connection_type]():
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ay/projects/personal/yop/.direnv/python-3.12.1/lib/python3.12/site-packages/ykman/device.py", line 71, in inner
    return f()
           ^^^
  File "/home/ay/projects/personal/yop/.direnv/python-3.12.1/lib/python3.12/site-packages/ykman/device.py", line 89, in list_ccid_devices
    return _list_ccid_devices()
           ^^^^^^^^^^^^^^^^^^^^
  File "/home/ay/projects/personal/yop/.direnv/python-3.12.1/lib/python3.12/site-packages/ykman/pcsc/__init__.py", line 169, in list_devices
    for reader in list_readers():
                  ^^^^^^^^^^^^^^
  File "/home/ay/projects/personal/yop/.direnv/python-3.12.1/lib/python3.12/site-packages/ykman/pcsc/__init__.py", line 157, in list_readers
    return System.readers()
           ^^^^^^^^^^^^^^^^
  File "/home/ay/projects/personal/yop/.direnv/python-3.12.1/lib/python3.12/site-packages/smartcard/System.py", line 41, in readers
    return smartcard.reader.ReaderFactory.ReaderFactory.readers(groups)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ay/projects/personal/yop/.direnv/python-3.12.1/lib/python3.12/site-packages/smartcard/reader/ReaderFactory.py", line 58, in readers
    zreaders += fm(groups)
                ^^^^^^^^^^
  File "/home/ay/projects/personal/yop/.direnv/python-3.12.1/lib/python3.12/site-packages/smartcard/pcsc/PCSCReader.py", line 111, in readers
    hcontext = PCSCContext().getContext()
               ^^^^^^^^^^^^^
  File "/home/ay/projects/personal/yop/.direnv/python-3.12.1/lib/python3.12/site-packages/smartcard/pcsc/PCSCContext.py", line 56, in __init__
    self.renewContext()
  File "/home/ay/projects/personal/yop/.direnv/python-3.12.1/lib/python3.12/site-packages/smartcard/pcsc/PCSCContext.py", line 70, in renewContext
    PCSCContext.instance = PCSCContext.__PCSCContextSingleton()
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ay/projects/personal/yop/.direnv/python-3.12.1/lib/python3.12/site-packages/smartcard/pcsc/PCSCContext.py", line 40, in __init__
    raise EstablishContextException(hresult)
smartcard.pcsc.PCSCExceptions.EstablishContextException: Failed to establish context: Service not available. (0x8010001D)
Unable to list devices for connection
Traceback (most recent call last):
  File "/home/ay/projects/personal/yop/.direnv/python-3.12.1/lib/python3.12/site-packages/ykman/device.py", line 291, in list_all_devices
    for dev in _CONNECTION_LIST_MAPPING[connection_type]():
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/ay/projects/personal/yop/.direnv/python-3.12.1/lib/python3.12/site-packages/ykman/device.py", line 71, in inner
    return f()
           ^^^
  File "/home/ay/projects/personal/yop/.direnv/python-3.12.1/lib/python3.12/site-packages/ykman/device.py", line 101, in list_otp_devices
    return _list_otp_devices()
           ^^^^^^^^^^^^^^^^^^^
  File "/home/ay/projects/personal/yop/.direnv/python-3.12.1/lib/python3.12/site-packages/ykman/hid/linux.py", line 130, in list_devices
    _failed_cache.difference_update(hidraw)
                                    ^^^^^^
UnboundLocalError: cannot access local variable 'hidraw' where it is not associated with a value
```

I believe the root cause of the problem is wrong indentation, which this PR fixes.