### PR TITLE
Send SIGHUP to `yubikey-agent` if it's running and the connection fails

### DIFF
--- a/ykman/pcsc/__init__.py
+++ b/ykman/pcsc/__init__.py
@@ -41,6 +41,10 @@ from time import sleep
 import subprocess  # nosec
 import logging
 
+import os
+import psutil
+import signal
+
 logger = logging.getLogger(__name__)
 
 
@@ -95,7 +99,7 @@ class ScardYubiKeyDevice(YkmanDevice):
         try:
             return ScardSmartCardConnection(self.reader.createConnection())
         except CardConnectionException as e:
-            if kill_scdaemon():
+            if kill_scdaemon() or kill_yubikey_agent():
                 return ScardSmartCardConnection(self.reader.createConnection())
             raise e
 
@@ -149,6 +153,17 @@ def kill_scdaemon():
             killed = True
     if killed:
         sleep(0.1)
+    return killed
+
+
+def kill_yubikey_agent():
+    killed = False
+    return_code = subprocess.call(["pkill", "-HUP", "yubikey-agent"])
+    if return_code == 0:
+        killed = True
+    if killed:
+        sleep(0.1)
+
     return killed
 
 


### PR DESCRIPTION
`yubikey-agent` is an SSH agent written in Go that uses the PIV module of a YubiKey for SSH[1].

Since it takes a persistent transaction on the YubiKey, using e.g. `ykman` will fail when it's active. I think it's tedious to always send a SIGHUP to it whenever I want to use `ykman`, so I added this small patch that does that for me. Inspired by what `age-plugin-yubikey` is also doing[2].

Not sure about Windows support, but I left it out because `yubikey-agent` doesn't do any Windows AFAIK and SIGHUP isn't supported there.

[1] https://github.com/FiloSottile/yubikey-agent
[2] https://github.com/str4d/age-plugin-yubikey/commit/1913838f8ed4b30c756c3c20ea5fdf1680ea97ca