### PR TITLE
Fixed docstring to reflect prior cli interface changes

### DIFF
--- a/ykman/_cli/oath.py
+++ b/ykman/_cli/oath.py
@@ -76,7 +76,7 @@ def oath(ctx):
 
     \b
       Set a password for the OATH application:
-      $ ykman oath access change-password
+      $ ykman oath access change
     """
 
     dev = ctx.obj["device"]


### PR DESCRIPTION
I noticed that in commit f1bbfc3a13ee0f6cef2656c365fbdc579da2d56f the cli interface was reworked and the functionality of the function `set_password` was incorporated into the new function `change`.
This PR fixed the docstring the wrongly changed during the rework.