### PR TITLE
OTP: settings: Add --serial-usb-visible option

### DIFF
--- a/ykman/_cli/otp.py
+++ b/ykman/_cli/otp.py
@@ -863,6 +863,12 @@ def hotp(ctx, slot, key, digits, counter, identifier, no_enter, force):
     help="use scancodes for numeric keypad when sending digits "
     "(helps for some keyboard layouts)",
 )
+@click.option(
+    "--serial-usb-visible",
+    is_flag=True,
+    show_default=True,
+    help="enable serial number in the USB iSerial field",
+)
 def settings(
     ctx,
     slot,
@@ -871,6 +877,7 @@ def settings(
     enter,
     pacing,
     use_numeric_keypad,
+    serial_usb_visible,
     force,
 ):
     """
@@ -926,6 +933,7 @@ def settings(
             UpdateConfiguration()
             .append_cr(enter)
             .use_numeric(use_numeric_keypad)
+            .serial_usb_visible(serial_usb_visible)
             .pacing(pacing_10ms, pacing_20ms),
             new_access_code,
             ctx.obj["access_code"],


### PR DESCRIPTION
Add a user-facing option to `ykman otp settings` to enable SERIAL_USB_VISIBLE. The underlying functionality is already implemented in yubikit.

This fixes #644 