### PR TITLE
tests: document FORM_FACTOR enum round-trip

### DIFF
--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -5,4 +5,5 @@ from yubikit.management import FORM_FACTOR
 
 @pytest.mark.parametrize("form_factor", list(FORM_FACTOR))
 def test_form_factor_from_code_accepts_enum_members(form_factor):
+    """Enum members should be accepted directly and round-trip unchanged."""
     assert form_factor == FORM_FACTOR.from_code(form_factor)


### PR DESCRIPTION
## Summary
- describe why the management-layer FORM_FACTOR test exists so its clear it verifies enum handling instead of raw values covered elsewhere

## Testing
- uv run --python 3.12 pytest