### PR TITLE
Add the CXF decompress method for X509 certificates

### DIFF
--- a/yubikit/piv.py
+++ b/yubikit/piv.py
@@ -420,7 +420,7 @@ _FASCN_LENS = (4, 4, 6, 1, 1, 10, 1, 4, 1)
 
 
 _cxf_dictionary = bytes([
-    # This data embed pre-computed structures used by the zlib deflate algorithm
+    # This data embeds pre-computed structures used by the zlib deflate algorithm
     # It's purpose is to avoid to store the full dictionary in the compressed
     # stream, thus reducing the size of the certificate
     # Source: https://datatracker.ietf.org/doc/html/draft-pritikin-comp-x509-00#appendix-A


### PR DESCRIPTION
Our key management system uses certificates in a fairly specific format corresponding to the "CXF" format defined in the draft [The Compressed X.509 Certificate Format](https://datatracker.ietf.org/doc/html/draft-pritikin-comp-x509-00).

Although this draft has not been elevated to RFC status and is now expired, the described format has been implemented by some current systems.

The purpose of this PR is to provide a simple way for Yubikey holders to read this certificate format using standard tools. It does not replace the historical operation of certificates decompression but adds two additional decompression methods selected via a simple heuristic: the first method that works provides the decompressed certificate.