### PR TITLE
Interpret TAG_MORE_DATA as number of following pages

### DIFF
--- a/yubikit/management.py
+++ b/yubikit/management.py
@@ -656,7 +656,7 @@ class ManagementSession:
                 raise BadResponseError("Invalid length")
             data = Tlv.parse_dict(encoded[1:])
             if TAG_MORE_DATA in data:
-                more_data = int.from_bytes(data.pop(TAG_MORE_DATA))
+                more_data = int.from_bytes(data.pop(TAG_MORE_DATA), byteorder="big")
             tlvs.update(data)
             page += 1
 

--- a/yubikit/management.py
+++ b/yubikit/management.py
@@ -645,16 +645,18 @@ class ManagementSession:
         return self._do_read_device_info()
 
     def _do_read_device_info(self) -> DeviceInfo:
-        more_data = True
+        more_data = 1
         tlvs = {}
         page = 0
         while more_data:
+            more_data -= 1
             logger.debug(f"Reading DeviceInfo page: {page}")
             encoded = self.backend.read_config(page)
             if len(encoded) - 1 != encoded[0]:
                 raise BadResponseError("Invalid length")
             data = Tlv.parse_dict(encoded[1:])
-            more_data = data.pop(TAG_MORE_DATA, 0) == b"\1"
+            if TAG_MORE_DATA in data:
+                more_data = int.from_bytes(data.pop(TAG_MORE_DATA))
             tlvs.update(data)
             page += 1
 


### PR DESCRIPTION
In future revisions of the firmware, the byte associated with `TAG_MORE_DATA` will be declaring the amount of pages available after the current one.