### PR TITLE
Improve PIV cert --subject error messages

### DIFF
--- a/ykman/_cli/piv.py
+++ b/ykman/_cli/piv.py
@@ -73,6 +73,7 @@ from ..util import (
 from .util import (
     CliFail,
     EnumChoice,
+    RFC4514StringParamType,
     click_callback,
     click_force_option,
     click_format_option,
@@ -1143,6 +1144,7 @@ def export_certificate(ctx, format, slot, certificate):
     "-s",
     "--subject",
     help="subject for the certificate, as an RFC 4514 string",
+    type=RFC4514StringParamType(),
     required=True,
 )
 @click.option(
@@ -1202,10 +1204,6 @@ def generate_certificate(
     now = datetime.datetime.now(datetime.timezone.utc)
     valid_to = now + datetime.timedelta(days=valid_days)
 
-    if "=" not in subject:
-        # Old style, common name only.
-        subject = "CN=" + subject
-
     # This verifies PIN, make sure next action is sign
     _ensure_authenticated(ctx, pin, management_key, require_pin_and_key=True)
 
@@ -1232,6 +1230,7 @@ def generate_certificate(
     "-s",
     "--subject",
     help="subject for the requested certificate, as an RFC 4514 string",
+    type=RFC4514StringParamType(),
     required=True,
 )
 @click_hash_option
@@ -1253,10 +1252,6 @@ def generate_certificate_signing_request(
 
     data = public_key.read()
     public_key = serialization.load_pem_public_key(data, default_backend())
-
-    if "=" not in subject:
-        # Old style, common name only.
-        subject = "CN=" + subject
 
     try:
         metadata = session.get_slot_metadata(slot)

--- a/ykman/_cli/util.py
+++ b/ykman/_cli/util.py
@@ -45,6 +45,7 @@ from yubikit.management import CAPABILITY, DeviceInfo
 from yubikit.oath import parse_b32_key
 from yubikit.securitydomain import SecurityDomainSession
 
+from ..piv import parse_rfc4514_string
 from ..util import parse_certificates
 
 logger = logging.getLogger(__name__)
@@ -158,6 +159,21 @@ class HexIntParamType(click.ParamType):
             return int(value)
         except ValueError:
             self.fail(f"{value!r} is not a valid integer", param, ctx)
+
+
+class RFC4514StringParamType(click.ParamType):
+    name = "text"
+
+    def convert(self, value, param, ctx) -> x509.Name:
+        if isinstance(value, x509.Name):
+            return value
+        if "=" not in value:
+            # Old style, common name only.
+            value = "CN=" + value
+        try:
+            return parse_rfc4514_string(value)
+        except ValueError as e:
+            self.fail(f"{e}: '{value}'", param, ctx)
 
 
 def click_callback(invoke_on_missing=False):

--- a/ykman/piv.py
+++ b/ykman/piv.py
@@ -145,6 +145,10 @@ def parse_rfc4514_string(value: str) -> x509.Name:
     )
     try:
         return x509.Name.from_rfc4514_string(value)
+    except ValueError as e:
+        if not str(e):
+            raise ValueError("Invalid RFC 4514 string") from e
+        raise
     except AttributeError:
         # cryptography < 37, use fallback implementation
         return _parse_rfc4514_string(value)
@@ -780,7 +784,7 @@ def generate_self_signed_certificate(
     session: PivSession,
     slot: SLOT,
     public_key: PublicKeyTypes,
-    subject_str: str,
+    subject: str | x509.Name,
     valid_from: datetime,
     valid_to: datetime,
     hash_algorithm: type[_AllowedHashTypes] = hashes.SHA256,
@@ -790,7 +794,7 @@ def generate_self_signed_certificate(
     :param session: The PIV session.
     :param slot: The slot.
     :param public_key: The public key.
-    :param subject_str: The subject RFC 4514 string.
+    :param subject: The subject RFC 4514 string or x509.Name.
     :param valid_from: The date from when the certificate is valid.
     :param valid_to: The date when the certificate expires.
     :param hash_algorithm: The hash algorithm.
@@ -800,7 +804,8 @@ def generate_self_signed_certificate(
     if TYPE_CHECKING:
         public_key = cast(CertificatePublicKeyTypes, public_key)
 
-    subject = parse_rfc4514_string(subject_str)
+    if not isinstance(subject, x509.Name):
+        subject = parse_rfc4514_string(subject)
     builder = (
         x509.CertificateBuilder()
         .public_key(public_key)
@@ -818,7 +823,7 @@ def generate_csr(
     session: PivSession,
     slot: SLOT,
     public_key: PublicKeyTypes,
-    subject_str: str,
+    subject: str | x509.Name,
     hash_algorithm: type[_AllowedHashTypes] = hashes.SHA256,
 ) -> x509.CertificateSigningRequest:
     """Generate a CSR using a private key in a slot.
@@ -826,12 +831,12 @@ def generate_csr(
     :param session: The PIV session.
     :param slot: The slot.
     :param public_key: The public key.
-    :param subject_str: The subject RFC 4514 string.
+    :param subject: The subject RFC 4514 string or x509.Name.
     :param hash_algorithm: The hash algorithm.
     """
     logger.debug("Generating a CSR")
-    builder = x509.CertificateSigningRequestBuilder().subject_name(
-        parse_rfc4514_string(subject_str)
-    )
+    if not isinstance(subject, x509.Name):
+        subject = parse_rfc4514_string(subject)
+    builder = x509.CertificateSigningRequestBuilder().subject_name(subject)
 
     return sign_csr_builder(session, slot, public_key, builder, hash_algorithm)


### PR DESCRIPTION
CLI/PIV: pass rfc4514 strings through Click

Get rfc4514 strings from the CLI via custom click.ParamType. This gives better error messages and skips asking for PIN on invalid input.

Commit d81541e1 changed certificate operations to use `from_rfc4514_string` from `cryptography`. Unlike the previous function this raises an exception on unescaped special characters (`\"+,'<> #=`) and the exception message is empty. This causes an unhelpful error message and makes it much more common:
```
$ uv run ykman piv certificates generate --subject 'CN=Example <example@example.com>' 82 82.pub
Enter a management key [blank to use default key]: 
Enter PIN: 
ERROR: 
$
```
After this change the output is more descriptive:
```
$ uv run ykman piv certificates generate --subject 'CN=Example <example@example.com>' 82 82.pub
Usage: ykman piv certificates generate [OPTIONS] SLOT PUBLIC-KEY
Try 'ykman piv certificates generate --help' for help.

Error: Invalid value for '-s' / '--subject': Invalid RFC 4514 string: 'CN=Example <example@example.com>'
$
```
And the error happens without asking for PIN.

A potential regression is that `-l warning` no longer gives a traceback on this error. Also, was dropping the automatic escaping deliberate? Maybe it should be added back instead of or in addition to this patch.